### PR TITLE
Add options for comma placement positions

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -15,17 +15,18 @@
 		"no-useless-concat": "off",
 		"prefer-template": "off",
 		"prettier/prettier": ["error"],
-		"require-unicode-regexp": ["error"],
-		"@typescript-eslint/naming-convention": "warn",
-		"@typescript-eslint/indent": "off",
-		"@typescript-eslint/semi": "warn",
-		"@typescript-eslint/lines-between-class-members": "off",
+		"require-unicode-regexp": ["warn"],
 		"@typescript-eslint/comma-dangle": "off",
+		"@typescript-eslint/indent": "off",
+		"@typescript-eslint/lines-between-class-members": "off",
+		"@typescript-eslint/naming-convention": "warn",
+		"@typescript-eslint/no-unused-vars": "warn",
 		"@typescript-eslint/quotes": [
 			"warn",
 			"single",
 			{ "avoidEscape": true, "allowTemplateLiterals": true }
-		]
+		],
+		"@typescript-eslint/semi": "warn"
 	},
 	"settings": {
 		"import/resolver": {

--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -5,5 +5,6 @@
 	"semi": true,
 	"bracketSpacing": true,
 	"useTabs": true,
-	"tabWidth": 2
+	"tabWidth": 2,
+	"endOfLine": "auto"
 }

--- a/src/core/Formatter.ts
+++ b/src/core/Formatter.ts
@@ -16,7 +16,7 @@ import {
 } from './token';
 import Tokenizer from './Tokenizer';
 import type { FormatOptions } from '../sqlFormatter';
-import { AliasMode, NewlineMode } from '../types';
+import { AliasMode, CommaPosition, NewlineMode } from '../types';
 
 export default class Formatter {
 	cfg: FormatOptions;

--- a/src/core/Formatter.ts
+++ b/src/core/Formatter.ts
@@ -85,9 +85,14 @@ export default class Formatter {
 	 */
 	format(query: string): string {
 		this.tokens = this.tokenizer().tokenize(query);
-		const formattedQuery = this.getFormattedQueryFromTokens();
+		const formattedQuery = this.getFormattedQueryFromTokens().trim();
+		const finalQuery = this.postFormat(formattedQuery);
 
-		return formattedQuery.trim();
+		return finalQuery;
+	}
+
+	postFormat(query: string) {
+		return query;
 	}
 
 	getFormattedQueryFromTokens() {

--- a/src/sqlFormatter.ts
+++ b/src/sqlFormatter.ts
@@ -11,7 +11,7 @@ import StandardSqlFormatter from './languages/StandardSqlFormatter';
 import TSqlFormatter from './languages/TSqlFormatter';
 
 import type { NewlineOptions } from './types';
-import { AliasMode, NewlineMode } from './types';
+import { AliasMode, CommaPosition, NewlineMode } from './types';
 
 export const formatters = {
 	db2: Db2Formatter,
@@ -34,6 +34,7 @@ export interface FormatOptions {
 	uppercase: boolean;
 	newline: NewlineOptions;
 	aliasAs: AliasMode | keyof typeof AliasMode;
+	commaPosition: CommaPosition | keyof typeof CommaPosition;
 	lineWidth: number;
 	linesBetweenQueries: number;
 	denseOperators: boolean;
@@ -52,6 +53,7 @@ export interface FormatOptions {
  *  	@param {NewlineMode} cfg.newline.mode always | never | lineWidth (break only when > line width) | itemCount (break when > itemCount) | hybrid (lineWidth OR itemCount)
  *  	@param {Integer} cfg.newline.itemCount Used when mode is itemCount or hybrid, must be >=0
  *  @param {AliasMode} cfg.aliasAs Whether to use AS in column aliases in only SELECT clause, both SELECT and table aliases, or never
+ *  @param {CommaPosition} cfg.commaPosition Where to place the comma in listed clauses
  *  @param {Integer} cfg.lineWidth Number of characters in each line before breaking, default: 50
  *  @param {Integer} cfg.linesBetweenQueries How many line breaks between queries
  *  @param {Boolean} cfg.denseOperators whether to format operators with spaces
@@ -95,6 +97,7 @@ export const format = (query: string, cfg: Partial<FormatOptions> = {}): string 
 		uppercase: true,
 		newline: { mode: NewlineMode.always },
 		aliasAs: AliasMode.select,
+		commaPosition: CommaPosition.after,
 		lineWidth: 50,
 		linesBetweenQueries: 1,
 		denseOperators: false,

--- a/src/types.ts
+++ b/src/types.ts
@@ -15,3 +15,9 @@ export enum AliasMode {
 	never = 'never',
 	select = 'select',
 }
+
+export enum CommaPosition {
+	before = 'before',
+	after = 'after',
+	tabular = 'tabular',
+}

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -16,3 +16,6 @@ export const sortByLengthDesc = (strings: string[]) =>
 	strings.sort((a, b) => {
 		return b.length - a.length || a.localeCompare(b);
 	});
+
+export const maxLength = (strings: string[]) =>
+	strings.reduce((max, cur) => Math.max(max, cur.length), 0);

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -19,3 +19,11 @@ export const sortByLengthDesc = (strings: string[]) =>
 
 export const maxLength = (strings: string[]) =>
 	strings.reduce((max, cur) => Math.max(max, cur.length), 0);
+
+export const tabulateLines = (...columns: string[][]) =>
+	columns.reduce((lines, cur) => {
+		const existingMaxLength = maxLength(lines);
+		return lines.map(
+			(line, i) => line + ' '.repeat(Math.max(existingMaxLength - line.length, 0) + 1) + cur[i]
+		);
+	});

--- a/test/features/comma.js
+++ b/test/features/comma.js
@@ -48,12 +48,44 @@ export default function supportsCommaModes(format) {
 		);
 	});
 
+	it('accepts comma before column', () => {
+		const result = format(
+			dedent(`
+			SELECT
+				alpha
+			, MAX(beta)
+			, delta AS d
+			, epsilon
+			FROM
+				gamma
+			GROUP BY
+				alpha
+			, delta
+			, epsilon
+			`)
+		);
+		expect(result).toBe(
+			dedent(`
+			SELECT
+			  alpha,
+			  MAX(beta),
+			  delta AS d,
+			  epsilon
+			FROM
+			  gamma
+			GROUP BY
+			  alpha,
+			  delta,
+			  epsilon
+			`)
+		);
+	});
+
 	it('supports tabular mode', () => {
 		const result = format(
 			'SELECT alpha, MAX(beta), delta AS d, epsilon FROM gamma GROUP BY alpha, delta, epsilon',
 			{ commaPosition: 'tabular' }
 		);
-		console.log(result);
 		expect(result).toBe(
 			dedent(`
 			SELECT
@@ -66,6 +98,39 @@ export default function supportsCommaModes(format) {
 			GROUP BY
 			  alpha  ,
 			  delta  ,
+			  epsilon
+			`)
+		);
+	});
+
+	it('accepts tabular mode', () => {
+		const result = format(
+			dedent(`
+			SELECT
+				alpha     ,
+				MAX(beta) ,
+				delta AS d,
+				epsilon
+			FROM
+				gamma
+			GROUP BY
+				alpha  ,
+				delta  ,
+				epsilon
+			`)
+		);
+		expect(result).toBe(
+			dedent(`
+			SELECT
+			  alpha,
+			  MAX(beta),
+			  delta AS d,
+			  epsilon
+			FROM
+			  gamma
+			GROUP BY
+			  alpha,
+			  delta,
 			  epsilon
 			`)
 		);

--- a/test/features/comma.js
+++ b/test/features/comma.js
@@ -1,0 +1,73 @@
+import dedent from 'dedent-js';
+
+/**
+ * Tests support for alias options
+ * @param {Function} format
+ */
+export default function supportsCommaModes(format) {
+	it('supports comma after column', () => {
+		const result = format(
+			'SELECT alpha, MAX(beta), delta AS d, epsilon FROM gamma GROUP BY alpha, delta, epsilon'
+		);
+		expect(result).toBe(
+			dedent(`
+			SELECT
+			  alpha,
+			  MAX(beta),
+			  delta AS d,
+			  epsilon
+			FROM
+			  gamma
+			GROUP BY
+			  alpha,
+			  delta,
+			  epsilon
+			`)
+		);
+	});
+
+	it('supports comma before column', () => {
+		const result = format(
+			'SELECT alpha, MAX(beta), delta AS d, epsilon FROM gamma GROUP BY alpha, delta, epsilon',
+			{ commaPosition: 'before' }
+		);
+		expect(result).toBe(
+			dedent(`
+			SELECT
+			  alpha
+			, MAX(beta)
+			, delta AS d
+			, epsilon
+			FROM
+			  gamma
+			GROUP BY
+			  alpha
+			, delta
+			, epsilon
+			`)
+		);
+	});
+
+	it('supports tabular mode', () => {
+		const result = format(
+			'SELECT alpha, MAX(beta), delta AS d, epsilon FROM gamma GROUP BY alpha, delta, epsilon',
+			{ commaPosition: 'tabular' }
+		);
+		console.log(result);
+		expect(result).toBe(
+			dedent(`
+			SELECT
+			  alpha     ,
+			  MAX(beta) ,
+			  delta AS d,
+			  epsilon
+			FROM
+			  gamma
+			GROUP BY
+			  alpha  ,
+			  delta  ,
+			  epsilon
+			`)
+		);
+	});
+}


### PR DESCRIPTION
Options for comma placement:
- after (default, standard)
- before (injects spaces before column name, assumes 4 space tabs by default)
- tabular (aligns with longest column name or expression in the same clause