### PR TITLE
Chore: Rename repo to prettier-sql

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# SQL Formatter [![NPM version](https://img.shields.io/npm/v/sql-formatter.svg)](https://npmjs.com/package/sql-formatter) [![Build Status](https://travis-ci.org/zeroturnaround/sql-formatter.svg?branch=master)](https://travis-ci.org/zeroturnaround/sql-formatter) [![Coverage Status](https://coveralls.io/repos/github/zeroturnaround/sql-formatter/badge.svg?branch=master)](https://coveralls.io/github/zeroturnaround/sql-formatter?branch=master)
+# SQL Formatter [![NPM version](https://img.shields.io/npm/v/prettier-sql.svg)](https://npmjs.com/package/prettier-sql) [![Build Status](https://travis-ci.org/inferrinizzard/prettier-sql.svg?branch=master)](https://travis-ci.org/inferrinizzard/prettier-sql) [![Coverage Status](https://coveralls.io/repos/github/inferrinizzard/prettier-sql/badge.svg?branch=master)](https://coveralls.io/github/inferrinizzard/prettier-sql?branch=master)
 
 **SQL Formatter** is a JavaScript library for pretty-printing SQL queries.
 It started as a port of a [PHP Library][], but has since considerably diverged.
@@ -21,7 +21,7 @@ It does not support:
 - Stored procedures.
 - Changing of the delimiter type to something else than `;`.
 
-→ [Try the demo.](https://zeroturnaround.github.io/sql-formatter/)
+→ [Try the demo.](https://inferrinizzard.github.io/prettier-sql/)
 
 # Table of contents
 
@@ -37,7 +37,7 @@ It does not support:
 Get the latest version from NPM:
 
 ```sh
-npm install sql-formatter
+npm install prettier-sql
 ```
 
 ## Usage
@@ -45,7 +45,7 @@ npm install sql-formatter
 ### Usage as library
 
 ```js
-import { format } from 'sql-formatter';
+import { format } from 'prettier-sql';
 
 console.log(format('SELECT * FROM tbl'));
 ```
@@ -97,11 +97,11 @@ WHERE
 
 ### Usage from command line
 
-The CLI tool will be installed under `sql-formatter`
-and may be invoked via `npx sql-formatter`:
+The CLI tool will be installed under `prettier-sql`
+and may be invoked via `npx prettier-sql`:
 
 ```sh
-sql-formatter -h
+prettier-sql -h
 ```
 
 ```
@@ -128,7 +128,7 @@ By default, the tool takes queries from stdin and processes them to stdout but
 one can also name an input file name or use the `--output` option.
 
 ```sh
-echo 'select * from tbl where id = 3' | sql-formatter
+echo 'select * from tbl where id = 3' | prettier-sql
 ```
 
 ```sql
@@ -184,7 +184,7 @@ npm run check
 
 ## License
 
-[MIT](https://github.com/zeroturnaround/sql-formatter/blob/master/LICENSE)
+[MIT](https://github.com/inferrinizzard/prettier-sql/blob/master/LICENSE)
 
 [php library]: https://github.com/jdorn/sql-formatter
 [standard sql]: https://en.wikipedia.org/wiki/SQL:2011

--- a/index.html
+++ b/index.html
@@ -4,17 +4,17 @@
 	<head>
 		<meta charset="utf-8" />
 
-		<title>SQL formatter</title>
-		<meta name="description" content="A whitespace formatter for different query languages" />
+		<title>Prettier SQL Formatter</title>
+		<meta property="og:title" content="Prettier SQL" />
 
-		<meta property="og:title" content="SQL Formatter" />
+		<meta name="description" content="A whitespace formatter for different query languages" />
 		<meta
 			property="og:description"
 			content="A whitespace formatter for different query languages"
 		/>
-		<meta property="og:url" content="https://zeroturnaround.github.io/sql-formatter" />
+		<meta property="og:url" content="https://inferrinizzard.github.io/prettier-sql" />
 
-		<link rel="shortcut icon" href="https://static.zeroturnaround.com/theme55/images/favicon.ico" />
+		<!-- <link rel="shortcut icon" href="https://static.inferrinizzard.com/theme55/images/favicon.ico" /> -->
 
 		<link href="https://fonts.googleapis.com/css?family=Roboto+Mono" rel="stylesheet" />
 
@@ -81,14 +81,14 @@
 
 	<body>
 		<header>
-			<h1>SQL Formatter</h1>
+			<h1>Prettier SQL Formatter</h1>
 
 			<div class="buttons">
-				<a href="https://www.npmjs.com/package/sql-formatter">
-					<img src="https://img.shields.io/npm/v/sql-formatter.svg" height="18" />
+				<a href="https://www.npmjs.com/package/prettier-sql">
+					<img src="https://img.shields.io/npm/v/prettier-sql.svg" height="18" />
 				</a>
 				<iframe
-					src="https://ghbtns.com/github-btn.html?user=zeroturnaround&repo=sql-formatter&type=star&count=true"
+					src="https://ghbtns.com/github-btn.html?user=inferrinizzard&repo=prettier-sql&type=star&count=true"
 					frameborder="0"
 					scrolling="0"
 					width="120px"
@@ -134,13 +134,13 @@ order by supplier_name asc,city desc;
 		</main>
 
 		<!-- Load from local (for development) -->
-		<script type="text/javascript" src="dist/sql-formatter.js"></script>
+		<script type="text/javascript" src="dist/prettier-sql.js"></script>
 		<!-- Fallback to reading from npm -->
 		<script>
 			window.sqlFormatter ||
 				document.write(
 					unescape(
-						'%3Cscript type="text/javascript" src="https://unpkg.com/sql-formatter@latest/dist/sql-formatter.min.js"%3E%3C/script%3E'
+						'%3Cscript type="text/javascript" src="https://unpkg.com/prettier-sql@latest/dist/prettier-sql.min.js"%3E%3C/script%3E'
 					)
 				);
 		</script>

--- a/package.json
+++ b/package.json
@@ -1,11 +1,11 @@
 {
-	"name": "sql-formatter",
+	"name": "prettier-sql",
 	"version": "5.0.0-beta",
 	"description": "Format whitespace in a SQL query to make it more readable",
 	"license": "MIT",
 	"main": "lib/sqlFormatter.js",
 	"bin": {
-		"sql-formatter": "./bin/sqlfmt.js"
+		"prettier-sql": "./bin/sqlfmt.js"
 	},
 	"keywords": [
 		"sql",
@@ -73,10 +73,10 @@
 	},
 	"repository": {
 		"type": "git",
-		"url": "https://github.com/zeroturnaround/sql-formatter.git"
+		"url": "https://github.com/inferrinizzard/prettier-sql.git"
 	},
 	"bugs": {
-		"url": "https://github.com/zeroturnaround/sql-formatter/issues"
+		"url": "https://github.com/inferrinizzard/prettier-sql/issues"
 	},
 	"dependencies": {
 		"argparse": "^2.0.1"

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -4,7 +4,7 @@ module.exports = {
 	entry: './src/sqlFormatter.ts',
 	output: {
 		path: path.join(__dirname, 'dist'),
-		filename: 'sql-formatter.js',
+		filename: 'prettier-sql.js',
 		library: 'sqlFormatter',
 		libraryTarget: 'umd',
 	},

--- a/webpack.prod.js
+++ b/webpack.prod.js
@@ -5,6 +5,6 @@ module.exports = merge(common, {
 	mode: 'production',
 	devtool: 'source-map',
 	output: {
-		filename: 'sql-formatter.min.js',
+		filename: 'prettier-sql.min.js',
 	},
 });


### PR DESCRIPTION
Renaming repo to prettier-sql to prep for npm release, edited files:
- package.json
- README
- webpack
- index.html