### PR TITLE
Fix Issue/inferrinizzard#7 - Update missing operators

### DIFF
--- a/src/core/Tokenizer.ts
+++ b/src/core/Tokenizer.ts
@@ -65,6 +65,7 @@ export default class Tokenizer {
 				'<>',
 				'<=',
 				'>=',
+				'!=',
 				...(cfg.operators ?? []),
 			]),
 			[TokenType.BLOCK_START]: regexFactory.createParenRegex(cfg.blockStart),

--- a/src/core/Tokenizer.ts
+++ b/src/core/Tokenizer.ts
@@ -61,13 +61,10 @@ export default class Tokenizer {
 			[TokenType.RESERVED_BINARY_COMMAND]: regexFactory.createReservedWordRegex(
 				cfg.reservedBinaryCommands
 			),
-			[TokenType.OPERATOR]: regexFactory.createOperatorRegex([
-				'<>',
-				'<=',
-				'>=',
-				'!=',
-				...(cfg.operators ?? []),
-			]),
+			[TokenType.OPERATOR]: regexFactory.createOperatorRegex(
+				['+', '-', '/', '*', '%', '&', '|', '^', '>', '<', '=', '.', ',', ';', '[', ']', '`', ':'],
+				['<>', '<=', '>=', '!=', ...(cfg.operators ?? [])]
+			),
 			[TokenType.BLOCK_START]: regexFactory.createParenRegex(cfg.blockStart),
 			[TokenType.BLOCK_END]: regexFactory.createParenRegex(cfg.blockEnd),
 			[TokenType.LINE_COMMENT]: regexFactory.createLineCommentRegex(cfg.lineCommentTypes),

--- a/src/core/regexFactory.ts
+++ b/src/core/regexFactory.ts
@@ -1,8 +1,10 @@
 import { escapeRegExp, isEmpty, sortByLengthDesc } from '../utils';
 
-export function createOperatorRegex(multiLetterOperators: string[]) {
+export function createOperatorRegex(monadOperators: string[], polyadOperators: string[]) {
 	return new RegExp(
-		`^(${sortByLengthDesc(multiLetterOperators).map(escapeRegExp).join('|')}|.)`,
+		`^(${sortByLengthDesc(polyadOperators).map(escapeRegExp).join('|')}|[${monadOperators
+			.map(escapeRegExp)
+			.join('')}])`,
 		'u'
 	);
 }

--- a/src/languages/Db2Formatter.ts
+++ b/src/languages/Db2Formatter.ts
@@ -873,7 +873,7 @@ export default class Db2Formatter extends Formatter {
 	static namedPlaceholderTypes = [':'];
 	static lineCommentTypes = ['--'];
 	static specialWordChars = ['#', '@'];
-	static operators = ['**', '!=', '!>', '!>', '||'];
+	static operators = ['**', '!>', '!<', '||'];
 
 	tokenizer() {
 		return new Tokenizer({

--- a/src/languages/MariaDbFormatter.ts
+++ b/src/languages/MariaDbFormatter.ts
@@ -1162,7 +1162,7 @@ export default class MariaDbFormatter extends Formatter {
 	static namedPlaceholderTypes = [];
 	static lineCommentTypes = ['--', '#'];
 	static specialWordChars = ['@'];
-	static operators = [':=', '<<', '>>', '!=', '<>', '<=>', '&&', '||'];
+	static operators = [':=', '<<', '>>', '<=>', '&&', '||'];
 
 	tokenizer() {
 		return new Tokenizer({

--- a/src/languages/MySqlFormatter.ts
+++ b/src/languages/MySqlFormatter.ts
@@ -1322,7 +1322,7 @@ export default class MySqlFormatter extends Formatter {
 	static namedPlaceholderTypes = [];
 	static lineCommentTypes = ['--', '#'];
 	static specialWordChars = ['@'];
-	static operators = [':=', '<<', '>>', '!=', '<>', '<=>', '&&', '||', '->', '->>'];
+	static operators = [':=', '<<', '>>', '<=>', '&&', '||', '->', '->>'];
 
 	tokenizer() {
 		return new Tokenizer({

--- a/src/languages/N1qlFormatter.ts
+++ b/src/languages/N1qlFormatter.ts
@@ -520,7 +520,7 @@ export default class N1qlFormatter extends Formatter {
 	static blockEnd = [')', ']', '}', 'END'];
 	static namedPlaceholderTypes = ['$'];
 	static lineCommentTypes = ['#', '--'];
-	static operators = ['==', '!='];
+	static operators = ['=='];
 
 	tokenizer() {
 		return new Tokenizer({

--- a/src/languages/PlSqlFormatter.ts
+++ b/src/languages/PlSqlFormatter.ts
@@ -452,7 +452,7 @@ export default class PlSqlFormatter extends Formatter {
 	static namedPlaceholderTypes = [':'];
 	static lineCommentTypes = ['--'];
 	static specialWordChars = ['_', '$', '#', '.', '@'];
-	static operators = ['||', '**', '!=', ':='];
+	static operators = ['||', '**', ':='];
 
 	tokenizer() {
 		return new Tokenizer({

--- a/src/languages/PlSqlFormatter.ts
+++ b/src/languages/PlSqlFormatter.ts
@@ -452,7 +452,17 @@ export default class PlSqlFormatter extends Formatter {
 	static namedPlaceholderTypes = [':'];
 	static lineCommentTypes = ['--'];
 	static specialWordChars = ['_', '$', '#', '.', '@'];
-	static operators = ['||', '**', ':=', '~=', '^=', '>>', '<<', '=>', '..'];
+	static operators = [
+		'||',
+		'**',
+		':=',
+		'~=',
+		'^=',
+		'>>',
+		'<<',
+		'=>',
+		//  '..' // breaks operator test, handled by .
+	];
 
 	tokenizer() {
 		return new Tokenizer({

--- a/src/languages/PlSqlFormatter.ts
+++ b/src/languages/PlSqlFormatter.ts
@@ -452,7 +452,7 @@ export default class PlSqlFormatter extends Formatter {
 	static namedPlaceholderTypes = [':'];
 	static lineCommentTypes = ['--'];
 	static specialWordChars = ['_', '$', '#', '.', '@'];
-	static operators = ['||', '**', ':='];
+	static operators = ['||', '**', ':=', '~=', '^=', '>>', '<<', '=>', '..'];
 
 	tokenizer() {
 		return new Tokenizer({

--- a/src/languages/PostgreSqlFormatter.ts
+++ b/src/languages/PostgreSqlFormatter.ts
@@ -1635,7 +1635,6 @@ export default class PostgreSqlFormatter extends Formatter {
 	static namedPlaceholderTypes = [':'];
 	static lineCommentTypes = ['--'];
 	static operators = [
-		'!=',
 		'<<',
 		'>>',
 		'||/',

--- a/src/languages/PostgreSqlFormatter.ts
+++ b/src/languages/PostgreSqlFormatter.ts
@@ -1618,6 +1618,51 @@ const reservedBinaryCommands = [
  */
 const reservedDependentClauses = ['ON', 'WHEN', 'THEN', 'ELSE', 'LATERAL'];
 
+const binaryOperators = [
+	'<<',
+	'>>',
+	'||/',
+	'|/',
+	'::',
+	':=',
+	'->>',
+	'->',
+	'=>',
+	'~~*',
+	'~~',
+	'!~~*',
+	'!~~',
+	'~*',
+	'!~*',
+	'!~',
+	'!!',
+	'||',
+	'@-@',
+	'@@',
+	'##',
+	'<->',
+	'&&',
+	'&<',
+	'&>',
+	'<<|',
+	'&<|',
+	'|>>',
+	'|&>',
+	'<^',
+	'^>',
+	'?#',
+	'?-',
+	'?|',
+	'?-|',
+	'?||',
+	'@>',
+	'<@',
+	'~=',
+	'>>=',
+	'<<=',
+	'@@@',
+];
+
 // https://www.postgresql.org/docs/14/index.html
 export default class PostgreSqlFormatter extends Formatter {
 	static reservedCommands = reservedCommands;
@@ -1634,23 +1679,7 @@ export default class PostgreSqlFormatter extends Formatter {
 	static indexedPlaceholderTypes = ['$'];
 	static namedPlaceholderTypes = [':'];
 	static lineCommentTypes = ['--'];
-	static operators = [
-		'<<',
-		'>>',
-		'||/',
-		'|/',
-		'::',
-		'->>',
-		'->',
-		'~~*',
-		'~~',
-		'!~~*',
-		'!~~',
-		'~*',
-		'!~*',
-		'!~',
-		'!!',
-	];
+	static operators = binaryOperators;
 
 	tokenizer() {
 		return new Tokenizer({

--- a/src/languages/RedshiftFormatter.ts
+++ b/src/languages/RedshiftFormatter.ts
@@ -729,7 +729,7 @@ export default class RedshiftFormatter extends Formatter {
 	static indexedPlaceholderTypes = ['?'];
 	static namedPlaceholderTypes = ['@', '#', '$'];
 	static lineCommentTypes = ['--'];
-	static operators = ['|/', '||', '||/', '<<', '>>'];
+	static operators = ['|/', '||/', '<<', '>>', '||'];
 
 	tokenizer() {
 		return new Tokenizer({

--- a/src/languages/RedshiftFormatter.ts
+++ b/src/languages/RedshiftFormatter.ts
@@ -729,7 +729,7 @@ export default class RedshiftFormatter extends Formatter {
 	static indexedPlaceholderTypes = ['?'];
 	static namedPlaceholderTypes = ['@', '#', '$'];
 	static lineCommentTypes = ['--'];
-	static operators = ['|/', '||/', '<<', '>>', '!=', '||'];
+	static operators = ['|/', '||', '||/', '<<', '>>'];
 
 	tokenizer() {
 		return new Tokenizer({

--- a/src/languages/SparkSqlFormatter.ts
+++ b/src/languages/SparkSqlFormatter.ts
@@ -790,7 +790,7 @@ export default class SparkSqlFormatter extends Formatter {
 	static indexedPlaceholderTypes = ['?'];
 	static namedPlaceholderTypes = ['$'];
 	static lineCommentTypes = ['--'];
-	static operators = ['!=', '<=>', '&&', '||', '=='];
+	static operators = ['<=>', '&&', '||', '=='];
 
 	tokenizer() {
 		return new Tokenizer({

--- a/src/languages/SparkSqlFormatter.ts
+++ b/src/languages/SparkSqlFormatter.ts
@@ -790,7 +790,7 @@ export default class SparkSqlFormatter extends Formatter {
 	static indexedPlaceholderTypes = ['?'];
 	static namedPlaceholderTypes = ['$'];
 	static lineCommentTypes = ['--'];
-	static operators = ['<=>', '&&', '||', '=='];
+	static operators = ['<=>', '&&', '||', '==', '->'];
 
 	tokenizer() {
 		return new Tokenizer({

--- a/src/languages/TSqlFormatter.ts
+++ b/src/languages/TSqlFormatter.ts
@@ -1244,23 +1244,7 @@ export default class TSqlFormatter extends Formatter {
 	static namedPlaceholderTypes = ['@'];
 	static lineCommentTypes = ['--'];
 	static specialWordChars = ['#', '@'];
-	static operators = [
-		'>=',
-		'<=',
-		'<>',
-		'!=',
-		'!<',
-		'!>',
-		'+=',
-		'-=',
-		'*=',
-		'/=',
-		'%=',
-		'|=',
-		'&=',
-		'^=',
-		'::',
-	];
+	static operators = ['!<', '!>', '+=', '-=', '*=', '/=', '%=', '|=', '&=', '^=', '::'];
 
 	tokenizer() {
 		return new Tokenizer({


### PR DESCRIPTION
Fixes #7

- Move common operators into main Tokenizer, dedupe language files
- add missing operators for Postgres, Spark
- convert operator regex to monad + polyad operator matching, with exhaustive list of monad operators