### PR TITLE
Add VSCode Command to format current selection

### DIFF
--- a/vscode/package.json
+++ b/vscode/package.json
@@ -43,7 +43,8 @@
 		"tsql"
 	],
 	"activationEvents": [
-		"onStartupFinished"
+		"onStartupFinished",
+		"onCommand:prettier-sql-vscode.format-selection"
 	],
 	"main": "./out/extension.js",
 	"scripts": {
@@ -93,13 +94,28 @@
 			{
 				"title": "Format Selection (Prettier-SQL)",
 				"shortTitle": "Format SQL",
-				"command": "prettier-sql-vscode.format-selection",
-				"enablement": ""
+				"command": "prettier-sql-vscode.format-selection"
 			}
 		],
 		"configuration": {
 			"title": "Prettier SQL",
 			"properties": {
+				"Prettier-SQL.ignoreTabSettings": {
+					"type": "boolean",
+					"default": true,
+					"markdownDescription": "Ignore user and workplace settings for `tabSize` and `insertSpaces` (uses `#Prettier-SQL.tabSizeOverride#` and `#Prettier-SQL.insertSpacesOverride#`)? "
+				},
+				"Prettier-SQL.tabSizeOverride": {
+					"type": "number",
+					"default": 4,
+					"minimum": 1,
+					"markdownDescription": "Override for `tabSize` if `#Prettier-SQL.ignoreTabSettings#` is active"
+				},
+				"Prettier-SQL.insertSpacesOverride": {
+					"type": "boolean",
+					"default": true,
+					"markdownDescription": "Override for `insertSpaces` if `#Prettier-SQL.ignoreTabSettings#` is active"
+				},
 				"Prettier-SQL.uppercaseKeywords": {
 					"type": "boolean",
 					"default": true,

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -89,6 +89,14 @@
 				]
 			}
 		],
+		"commands": [
+			{
+				"title": "Format Selection (Prettier-SQL)",
+				"shortTitle": "Format SQL",
+				"command": "prettier-sql-vscode.format-selection",
+				"enablement": ""
+			}
+		],
 		"configuration": {
 			"title": "Prettier SQL",
 			"properties": {

--- a/vscode/src/extension.ts
+++ b/vscode/src/extension.ts
@@ -8,6 +8,37 @@ import type {
 	NewlineMode,
 } from 'prettier-sql';
 
+const getConfigs = (
+	settings: vscode.WorkspaceConfiguration,
+	formattingOptions: vscode.FormattingOptions,
+	language: FormatterLanguage
+) => {
+	const { tabSize, insertSpaces } = formattingOptions;
+	const indent = insertSpaces ? ' '.repeat(tabSize) : '\t';
+
+	const formatConfigs = {
+		language,
+		indent,
+		uppercase: settings.get<boolean>('uppercaseKeywords'),
+		keywordPosition: settings.get<KeywordMode>('keywordPosition'),
+		breakBeforeBooleanOperator: settings.get<boolean>('breakBeforeBooleanOperator'),
+		aliasAs: settings.get<AliasMode>('aliasAS'),
+		tabulateAlias: settings.get<boolean>('tabulateAlias'),
+		commaPosition: settings.get<CommaPosition>('commaPosition'),
+		newlineOptions: settings.get<NewlineMode | number>('keywordNewline'),
+		parenOptions: {
+			openParenNewline: settings.get<boolean>('openParenNewline'),
+			closeParenNewline: settings.get<boolean>('closeParenNewline'),
+		},
+		lineWidth: settings.get<number>('lineWidth'),
+		linesBetweenQueries: settings.get<number>('linesBetweenQueries'),
+		denseOperators: settings.get<boolean>('denseOperators'),
+		semicolonNewline: settings.get<boolean>('semicolonNewline'),
+	};
+
+	return formatConfigs;
+};
+
 export function activate(context: vscode.ExtensionContext) {
 	console.log('Prettier-SQL VSCode activated');
 
@@ -19,30 +50,9 @@ export function activate(context: vscode.ExtensionContext) {
 			console.log('Formatter language:', language);
 
 			const settings = vscode.workspace.getConfiguration('Prettier-SQL');
-			const { tabSize, insertSpaces } = options;
-			const indent = insertSpaces ? ' '.repeat(tabSize) : '\t';
+			const formatConfigs = getConfigs(settings, options, language);
 
 			const lines = [...new Array(document.lineCount)].map((_, i) => document.lineAt(i).text);
-			const formatConfigs = {
-				language,
-				indent,
-				uppercase: settings.get<boolean>('uppercaseKeywords'),
-				keywordPosition: settings.get<KeywordMode>('keywordPosition'),
-				breakBeforeBooleanOperator: settings.get<boolean>('breakBeforeBooleanOperator'),
-				aliasAs: settings.get<AliasMode>('aliasAS'),
-				tabulateAlias: settings.get<boolean>('tabulateAlias'),
-				commaPosition: settings.get<CommaPosition>('commaPosition'),
-				newlineOptions: settings.get<NewlineMode | number>('keywordNewline'),
-				parenOptions: {
-					openParenNewline: settings.get<boolean>('openParenNewline'),
-					closeParenNewline: settings.get<boolean>('closeParenNewline'),
-				},
-				lineWidth: settings.get<number>('lineWidth'),
-				linesBetweenQueries: settings.get<number>('linesBetweenQueries'),
-				denseOperators: settings.get<boolean>('denseOperators'),
-				semicolonNewline: settings.get<boolean>('semicolonNewline'),
-			};
-
 			const text = format(lines.join('\n'), formatConfigs);
 
 			return [

--- a/vscode/src/extension.ts
+++ b/vscode/src/extension.ts
@@ -13,7 +13,13 @@ const getConfigs = (
 	formattingOptions: vscode.FormattingOptions | { tabSize: number; insertSpaces: boolean },
 	language: FormatterLanguage
 ) => {
-	const { tabSize, insertSpaces } = formattingOptions;
+	const ignoreTabSettings = settings.get<boolean>('ignoreTabSettings');
+	const { tabSize, insertSpaces } = ignoreTabSettings
+		? {
+				tabSize: settings.get<number>('tabSizeOverride')!,
+				insertSpaces: settings.get<boolean>('insertSpacesOverride')!,
+		  }
+		: formattingOptions;
 	const indent = insertSpaces ? ' '.repeat(tabSize) : '\t';
 
 	const formatConfigs = {

--- a/vscode/src/extension.ts
+++ b/vscode/src/extension.ts
@@ -10,7 +10,7 @@ import type {
 
 const getConfigs = (
 	settings: vscode.WorkspaceConfiguration,
-	formattingOptions: vscode.FormattingOptions,
+	formattingOptions: vscode.FormattingOptions | { tabSize: number; insertSpaces: boolean },
 	language: FormatterLanguage
 ) => {
 	const { tabSize, insertSpaces } = formattingOptions;
@@ -84,6 +84,15 @@ export function activate(context: vscode.ExtensionContext) {
 			)
 		)
 	);
+
+	const formatSelectionCommand = vscode.commands.registerCommand(
+		'prettier-sql-vscode.format-selection',
+		() => {
+			console.log('format selection command');
+		}
+	);
+
+	context.subscriptions.push(formatSelectionCommand);
 }
 
 export function deactivate() {}

--- a/vscode/src/extension.ts
+++ b/vscode/src/extension.ts
@@ -46,15 +46,11 @@ const getConfigs = (
 };
 
 export function activate(context: vscode.ExtensionContext) {
-	console.log('Prettier-SQL VSCode activated');
-
 	const formatProvider = (language: FormatterLanguage) => ({
 		provideDocumentFormattingEdits(
 			document: vscode.TextDocument,
 			options: vscode.FormattingOptions
 		): vscode.TextEdit[] {
-			console.log('Formatter language:', language);
-
 			const settings = vscode.workspace.getConfiguration('Prettier-SQL');
 			const formatConfigs = getConfigs(settings, options, language);
 
@@ -80,7 +76,7 @@ export function activate(context: vscode.ExtensionContext) {
 		'postgres': 'postgresql',
 		'hql': 'sql',
 		'hive-sql': 'sql',
-		// 'sql-bigquery': 'bigquery',
+		'sql-bigquery': 'bigquery',
 	};
 	Object.entries(languages).forEach(([vscodeLang, prettierLang]) =>
 		context.subscriptions.push(
@@ -117,7 +113,7 @@ export function activate(context: vscode.ExtensionContext) {
 
 			const editor = vscode.window.activeTextEditor;
 			editor?.edit(editBuilder => {
-				editor?.selections?.forEach(sel =>
+				editor.selections.forEach(sel =>
 					editBuilder.replace(sel, format(editor.document.getText(sel), formatConfigs))
 				);
 			});


### PR DESCRIPTION
- added `prettier-sql-vscode.format-selection` Command to Extension Manifest
- formats all user selections in current document according to current language detected, defaults to SQL
- also added settings to override user's `tabSize` and `insertSpaces` settings