### PR TITLE
Add error handling and SQL Flavour override

### DIFF
--- a/vscode/package.json
+++ b/vscode/package.json
@@ -100,10 +100,29 @@
 		"configuration": {
 			"title": "Prettier SQL",
 			"properties": {
+				"Prettier-SQL.SQLFlavourOverride": {
+					"type": "string",
+					"enum": [
+						"sql",
+						"bigquery",
+						"db2",
+						"hive",
+						"mariadb",
+						"mysql",
+						"n1ql",
+						"plsql",
+						"postgresql",
+						"redshift",
+						"spark",
+						"tsql"
+					],
+					"default": "sql",
+					"markdownDescription": "Formats `sql` files in another SQL Flavour when no VSCode Language exists, such as the Microsoft PostgreSQL & MSSQL Extensions"
+				},
 				"Prettier-SQL.ignoreTabSettings": {
 					"type": "boolean",
 					"default": true,
-					"markdownDescription": "Ignore user and workplace settings for `tabSize` and `insertSpaces` (uses `#Prettier-SQL.tabSizeOverride#` and `#Prettier-SQL.insertSpacesOverride#`)? "
+					"markdownDescription": "Ignore user and workplace settings for `tabSize` and `insertSpaces` (uses `#Prettier-SQL.tabSizeOverride#` and `#Prettier-SQL.insertSpacesOverride#`)?"
 				},
 				"Prettier-SQL.tabSizeOverride": {
 					"type": "number",

--- a/vscode/src/extension.ts
+++ b/vscode/src/extension.ts
@@ -55,7 +55,13 @@ export function activate(context: vscode.ExtensionContext) {
 			const formatConfigs = getConfigs(settings, options, language);
 
 			const lines = [...new Array(document.lineCount)].map((_, i) => document.lineAt(i).text);
-			const text = format(lines.join('\n'), formatConfigs);
+			let text;
+			try {
+				text = format(lines.join('\n'), formatConfigs);
+			} catch (e) {
+				vscode.window.showErrorMessage('Unable to format SQL:\n' + e);
+				return [];
+			}
 
 			return [
 				vscode.TextEdit.replace(
@@ -112,11 +118,15 @@ export function activate(context: vscode.ExtensionContext) {
 			const formatConfigs = getConfigs(settings, options, formatterLanguage);
 
 			const editor = vscode.window.activeTextEditor;
-			editor?.edit(editBuilder => {
-				editor.selections.forEach(sel =>
-					editBuilder.replace(sel, format(editor.document.getText(sel), formatConfigs))
-				);
-			});
+			try {
+				editor?.edit(editBuilder => {
+					editor.selections.forEach(sel =>
+						editBuilder.replace(sel, format(editor.document.getText(sel), formatConfigs))
+					);
+				});
+			} catch (e) {
+				vscode.window.showErrorMessage('Unable to format SQL:\n' + e);
+			}
 		}
 	);
 

--- a/vscode/src/extension.ts
+++ b/vscode/src/extension.ts
@@ -23,7 +23,10 @@ const getConfigs = (
 	const indent = insertSpaces ? ' '.repeat(tabSize) : '\t';
 
 	const formatConfigs = {
-		language,
+		language:
+			language === 'sql'
+				? settings.get<FormatterLanguage>('SQLFlavourOverride') ?? 'sql'
+				: language,
 		indent,
 		uppercase: settings.get<boolean>('uppercaseKeywords'),
 		keywordPosition: settings.get<KeywordMode>('keywordPosition'),


### PR DESCRIPTION
Workaround for #54 
 - use `Prettier-SQL.SQLFlavourOverride` to force `sql` files to be formatted with PostgreSQL if using the Microsoft PostgreSQL Extension
 - repeat with TSQL and the Microsoft MSSQL Extension

- also added error messages on format fail