### PR TITLE
Implement support for parsing numbers with trailing floating-point

### DIFF
--- a/src/core/Tokenizer.ts
+++ b/src/core/Tokenizer.ts
@@ -83,7 +83,7 @@ export default class Tokenizer {
 			[TokenType.LINE_COMMENT]: regexFactory.createLineCommentRegex(cfg.lineCommentTypes),
 			[TokenType.BLOCK_COMMENT]: /^(\/\*[^]*?(?:\*\/|$))/u,
 			[TokenType.NUMBER]:
-				/^((-\s*)?[0-9]+(\.[0-9]+)?([eE][-+]?[0-9]+(\.[0-9]+)?)?|0x[0-9a-fA-F]+|0b[01]+)\b/u,
+				/^((-\s*)?[0-9]+(\.[0-9]*)?([eE][-+]?[0-9]+(\.[0-9]+)?)?|0x[0-9a-fA-F]+|0b[01]+)/u,
 			[TokenType.PLACEHOLDER]: NULL_REGEX, // matches nothing
 		};
 

--- a/test/behavesLikeSqlFormatter.js
+++ b/test/behavesLikeSqlFormatter.js
@@ -121,7 +121,7 @@ export default function behavesLikeSqlFormatter(format) {
 		expect(result).toBe(dedent`
       LIMIT
         5;
-      
+
       SELECT
         foo,
         bar;
@@ -378,7 +378,7 @@ export default function behavesLikeSqlFormatter(format) {
         Column1
       FROM
         Table1;
-      
+
       SELECT
         COUNT(*),
         Column1
@@ -408,7 +408,7 @@ export default function behavesLikeSqlFormatter(format) {
         *
       FROM
         test;
-      
+
       CREATE TABLE
         test(
           id NUMBER NOT NULL,
@@ -427,6 +427,22 @@ export default function behavesLikeSqlFormatter(format) {
         3.5E12 AS c,
         3.5e12 AS d;
     `);
+	});
+
+	it('correctly handles floats with trailing point', () => {
+		let result = format('SELECT 1000. AS a;');
+		expect(result).toBe(dedent`
+		  SELECT
+		    1000. AS a;
+		`);
+
+		result = format('SELECT a, b / 1000. AS a_s, 100. * b / SUM(a_s);');
+		expect(result).toBe(dedent`
+		  SELECT
+        a,
+        b / 1000. AS a_s,
+        100.* b / SUM(a_s);
+		`);
 	});
 
 	it('does not split UNION ALL in half', () => {

--- a/test/behavesLikeSqlFormatter.js
+++ b/test/behavesLikeSqlFormatter.js
@@ -439,10 +439,10 @@ export default function behavesLikeSqlFormatter(format) {
 		result = format('SELECT a, b / 1000. AS a_s, 100. * b / SUM(a_s);');
 		expect(result).toBe(dedent`
 		  SELECT
-        a,
-        b / 1000. AS a_s,
-        100.* b / SUM(a_s);
-		`);
+		    a,
+		    b / 1000. AS a_s,
+		    100. * b / SUM(a_s);
+	  `);
 	});
 
 	it('does not split UNION ALL in half', () => {


### PR DESCRIPTION
**SQL:**
```sql
SELECT 1000. AS a;

SELECT a, b / 1000. AS a_s, 100. * b / SUM(a_s);
```

**Expected output:**
```sql
SELECT
  1000. AS a;

SELECT
  a,
  b / 1000. AS a_s,
  100. * b / SUM(a_s);
```

**Actual output:**
```sql
SELECT
  1000.AS a;

SELECT
  a,
  b / 1000.AS AS a_s,
  100.* b / SUM(a_s);
```