### PR TITLE
Release v5.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # CHANGELOG
 
+## [5.1.1] : 2022-04-06
+
+### Updated
+
+- restored itemCount setting for VScode extension
+- added JSDocs for all files
+- added conditional skips for Jest tests
+- added missing BigQuery, hive from demo page language dropdown
+
+### Fixed
+
+- fixed bug with CASE and Inline Block interaction
+- fixed bug with END not adding spacings before END
+- fixed bug with CommaPosition.before when the line had no preceding whitespace
+- fixed bug where AS in CAST functions would get deleted when AliasAs.never
+- fixed bug where AS would get deleted in CTE definition when AliasAs.never
+
 ## [5.1.0] : 2021-12-21
 
 ### Known Issues

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -54,9 +54,11 @@ For those who have admin access on the repo, the new release publish flow is as 
 
 - `release-it` (bumps version, git tag, git release, npm release)
 - bump VSCode version + prettier-sql dependency version (can be done beforehand, must be done before push)
-- `git subtree push --prefix static origin gh-pages` && `gh pages deploy` (pushes demo page to GH pages)
+- `git subtree push --prefix static origin gh-pages` (pushes demo page to GH pages)
 - `git dio develop` (moves origin/develop branch head to master)
+  - alias for `git push --force-with-lease origin HEAD:develop`
 - `vscode deploy` (run within vscode/ subrepo, deploys VSCode Extension)
+  - `npx vsce publish` (required authenticated PAT (Personal Access Token))
 
 # Contributors
 

--- a/DOC.md
+++ b/DOC.md
@@ -1,0 +1,40 @@
+# Prettier-SQL
+
+## Overview:
+
+This formatter generally follows this flow:
+
+- `<sql>.formatter.ts` files are created for each support dialect that defined a mostly exhaustive list of Reserved Keywords\*
+- this formatter class is then passed to the lexer, which tokenises the SQL input string and produces a token stream\*\*
+- the token stream is then directly formatted sequentially by the `format()` method, without a parsing step\*\*\*
+
+\*some more edge case work needs to be done regarding identifying keywords that are multiple words instead of single words
+
+\*\*this tokenizer is set to be replaced in the v5.2 release (Moo)
+
+\*\*\*a parser is set to be added in the future with the v6 release (Nearley)
+
+## Tokenizer:
+
+The tokenizer consumes the lists of tokens from the formatter class files, joined them into respective regular expressions. \
+These regular expressions are then tested in order of priority, allowing Reserved Keywords and Reserved Commands to be matched before common identifiers or operators.
+
+The current priority order is:
+
+- Line Comment (denotes comments across the entire line)
+- Block Comment (denotes comments within a block)
+- Strings (only specific tokens beginning and ending with the supported string delimiters)
+- Block Start tokens (such as Left Parenthesis, Left Bracket, Left Brace, and CASE)
+- Block End tokens (such as Right Parenthesis, Right Bracket, Right Brace, and END)
+- Placeholder tokens (used for variable substitution)
+- Numbers (must match a common numeric format, such as floats or scientific notation)
+- Reserved words (denotes words that are reserved in the SQL dialect)
+
+  - Reserved Commands (begins its own clause, such as `SELECT`)
+  - Reserved Binary Commands (connect two adjacent clauses, such as joins or set operations)
+  - Reserved Dependent Clauses (keywords that are dependent on the previous clause, such as `ON` for joins or `WHEN` and `THEN` for CASE)
+  - Reserved Logical Operator (boolean operators such as `AND` and `OR`)
+  - Reserved Keywords/Functions (other reserved words)
+
+- Word tokens (aka common identifiers)
+- Operators (any supported operators comprised of special characters)

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ It does not support:
 # Table of contents
 
 - [Install](#install)
+- [Documentation](#documentation)
 - [Usage](#usage)
   - [Usage as library](#usage-as-library)
   - [Usage from command line](#usage-from-command-line)
@@ -51,6 +52,10 @@ Also available with yarn:
 ```sh
 yarn add prettier-sql
 ```
+
+## Documentation
+
+You can read more about how the library works in [DOC.md](DOC.md)
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <a href='https://github.com/inferrinizzard/prettier-sql'><img src="static/prettier-sql-clean.svg" width="128"/></a>
 
-# Prettier SQL [![NPM version](https://img.shields.io/npm/v/prettier-sql.svg)](https://npmjs.com/package/prettier-sql) ![GitHub Workflow Status (event)](https://img.shields.io/github/workflow/status/inferrinizzard/prettier-sql/coveralls/master?label=Build&logo=Github) ![Coveralls](https://img.shields.io/coveralls/github/inferrinizzard/prettier-sql?branch=master&label=Coverage&logo=coveralls&style=plastic)
+# Prettier SQL [![NPM version](https://img.shields.io/npm/v/prettier-sql.svg)](https://npmjs.com/package/prettier-sql) ![GitHub Workflow Status (event)](https://img.shields.io/github/workflow/status/inferrinizzard/prettier-sql/coveralls/master?label=Build&logo=Github) ![Coveralls](https://img.shields.io/coveralls/github/inferrinizzard/prettier-sql?branch=master&label=Coverage&logo=coveralls&style=plastic) [![VSCode](https://img.shields.io/visual-studio-marketplace/v/inferrinizzard.prettier-sql-vscode?label=vscode)](https://marketplace.visualstudio.com/items?itemName=inferrinizzard.prettier-sql-vscode)
 
 ## **Prettier SQL** is a JavaScript library for pretty-printing SQL queries.
 

--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
 		"@babel/plugin-proposal-class-properties": "^7.10.4",
 		"@babel/preset-env": "^7.10.4",
 		"@babel/preset-typescript": "^7.15.0",
+		"@jest/globals": "^27.5.1",
 		"@types/babel__core": "^7.1.15",
 		"@typescript-eslint/eslint-plugin": "^4.31.2",
 		"@typescript-eslint/parser": "^4.32.0",

--- a/src/core/Formatter.ts
+++ b/src/core/Formatter.ts
@@ -116,17 +116,26 @@ export default class Formatter {
 					const isTabs = this.cfg.indent.includes('\t'); // loose tab check
 					commaLines = commaLines.map(commaLine => commaLine.replace(/,$/, ''));
 					const whitespaceRegex = this.tokenizer().WHITESPACE_REGEX;
-					commaLines = commaLines.map((commaLine, j) =>
-						j // do not add comma for first item
-							? commaLine.replace(
-									whitespaceRegex,
-									commaLine.match(whitespaceRegex)![1].replace(
-										new RegExp((isTabs ? '\t' : this.cfg.indent) + '$'), // replace last two spaces in preceding whitespace with ', '
-										(isTabs ? '    ' : this.cfg.indent).replace(/ {2}$/, ', ') // using 4 width tabs
-									)
+
+					commaLines = commaLines.map((commaLine, j) => {
+						if (!j) {
+							// do not add comma for first item
+							return commaLine;
+						}
+						const precedingWhitespace = commaLine.match(new RegExp('^' + whitespaceRegex + ''));
+						const trimLastIndent = precedingWhitespace
+							? precedingWhitespace[1].replace(
+									new RegExp((isTabs ? '\t' : this.cfg.indent) + '$'), // remove last tab / last indent
+									''
 							  )
-							: commaLine
-					);
+							: '';
+						return (
+							trimLastIndent +
+							// add comma in place of last indent
+							(isTabs ? '    ' : this.cfg.indent).replace(/ {2}$/, ', ') + // using 4 width tabs
+							commaLine.trimStart()
+						);
+					});
 				}
 
 				newQuery = [...newQuery, ...commaLines];

--- a/src/core/Formatter.ts
+++ b/src/core/Formatter.ts
@@ -227,16 +227,13 @@ export default class Formatter {
 			} else if (token.type === TokenType.OPERATOR) {
 				formattedQuery = this.formatOperator(token, formattedQuery);
 			} else {
-				if (this.cfg.aliasAs !== AliasMode.never) {
-					formattedQuery = this.formatAliases(token, formattedQuery);
-				}
-				formattedQuery = this.formatWithSpaces(token, formattedQuery);
+				formattedQuery = this.formatWord(token, formattedQuery);
 			}
 		}
 		return formattedQuery.replace(new RegExp(ZWS, 'ugim'), ' ');
 	}
 
-	formatAliases(token: Token, query: string) {
+	formatWord = (token: Token, query: string): string => {
 		const prevToken = this.tokenLookBehind();
 		const nextToken = this.tokenLookAhead();
 		const asToken = { type: TokenType.RESERVED_KEYWORD, value: this.cfg.uppercase ? 'AS' : 'as' };
@@ -247,16 +244,39 @@ export default class Formatter {
 			prevToken?.value === ')';
 
 		const missingSelectColumnAlias = // if select column alias is missing and alias is not never
+			this.cfg.aliasAs !== AliasMode.never &&
 			this.withinSelect &&
 			token.type === TokenType.WORD &&
 			(isToken.END(prevToken) || // isAs(prevToken) ||
 				(prevToken?.type === TokenType.WORD && (nextToken?.value === ',' || isCommand(nextToken))));
 
+		const isEdgeCaseCTE = // checks for WITH `table` [AS] (
+			this.cfg.aliasAs === AliasMode.never &&
+			isToken.WITH(prevToken) &&
+			(nextToken?.value === '(' ||
+				(isToken.AS(nextToken) && this.tokenLookAhead(2)?.value === '('));
+
+		const isEdgeCaseCreateTable = // checks for CREATE TABLE `table` [AS] WITH (
+			this.cfg.aliasAs === AliasMode.never &&
+			(isToken.TABLE(prevToken) || prevToken?.value.endsWith('TABLE')) &&
+			(isToken.WITH(nextToken) || (isToken.AS(nextToken) && isToken.WITH(this.tokenLookAhead(2))));
+
+		let finalQuery = query;
 		if (missingTableAlias || missingSelectColumnAlias) {
-			return this.formatWithSpaces(asToken, query);
+			// insert AS before word
+			finalQuery = this.formatWithSpaces(asToken, finalQuery);
 		}
-		return query;
-	}
+
+		// insert word
+		finalQuery = this.formatWithSpaces(token, finalQuery);
+
+		if (isEdgeCaseCTE || isEdgeCaseCreateTable) {
+			// insert AS after word
+			finalQuery = this.formatWithSpaces(asToken, finalQuery);
+		}
+
+		return finalQuery;
+	};
 
 	checkNewline = (index: number) => {
 		const tail = this.tokens.slice(index + 1);

--- a/src/core/Formatter.ts
+++ b/src/core/Formatter.ts
@@ -462,7 +462,10 @@ export default class Formatter {
 	formatBlockEnd(token: Token, query: string) {
 		if (this.inlineBlock.isActive()) {
 			this.inlineBlock.end();
-			return this.formatWithSpaces(token, query, 'after');
+			if (isToken.END(token)) {
+				return this.formatWithSpaces(token, query); // add space before END when closing inline block
+			}
+			return this.formatWithSpaces(token, query, 'after'); // do not add space before )
 		} else {
 			this.indentation.decreaseBlockLevel();
 

--- a/src/core/Indentation.ts
+++ b/src/core/Indentation.ts
@@ -16,7 +16,7 @@ export default class Indentation {
 	indentTypes: string[];
 
 	/**
-	 * @param {String} indent Indent value, default is "  " (2 spaces)
+	 * @param {string} indent Indent value, default is "  " (2 spaces)
 	 */
 	constructor(indent: string = '  ') {
 		this.indent = indent;
@@ -25,7 +25,7 @@ export default class Indentation {
 
 	/**
 	 * Returns current indentation string.
-	 * @return {String}
+	 * @return {string} indentation string based on indentTypes
 	 */
 	getIndent(): string {
 		return this.indent.repeat(this.indentTypes.length);
@@ -69,6 +69,7 @@ export default class Indentation {
 		}
 	}
 
+	/** Clears all indentation */
 	resetIndentation() {
 		this.indentTypes = [];
 	}

--- a/src/core/InlineBlock.ts
+++ b/src/core/InlineBlock.ts
@@ -3,8 +3,8 @@ import { isToken, Token, TokenType } from './token';
 /**
  * Bookkeeper for inline blocks.
  *
- * Inline blocks are parenthized expressions that are shorter than INLINE_MAX_LENGTH.
- * These blocks are formatted on a single line, unlike longer parenthized
+ * Inline blocks are parenthesised expressions that are shorter than INLINE_MAX_LENGTH.
+ * These blocks are formatted on a single line, unlike longer parenthesised
  * expressions where open-parenthesis causes newline and increase of indentation.
  */
 export default class InlineBlock {
@@ -42,15 +42,16 @@ export default class InlineBlock {
 
 	/**
 	 * True when inside an inline block
-	 * @return {Boolean}
 	 */
 	isActive(): boolean {
 		return this.level > 0;
 	}
 
-	// Check if this should be an inline parentheses block
-	// Examples are "NOW()", "COUNT(*)", "int(10)", key(`somecolumn`), DECIMAL(7,2)
-	isInlineBlock(tokens: Token[], index: number) {
+	/**
+	 * Check if this should be an inline parentheses block
+	 * Examples are "NOW()", "COUNT(*)", "int(10)", key(`somecolumn`), DECIMAL(7,2)
+	 */
+	isInlineBlock(tokens: Token[], index: number): boolean {
 		let length = 0;
 		let level = 0;
 

--- a/src/core/InlineBlock.ts
+++ b/src/core/InlineBlock.ts
@@ -58,6 +58,10 @@ export default class InlineBlock {
 			const token = tokens[i];
 			length += token.value.length;
 
+			if (this.isForbiddenToken(token)) {
+				return false;
+			}
+
 			// Overran max length
 			if (length > this.lineWidth) {
 				return false;
@@ -72,10 +76,6 @@ export default class InlineBlock {
 					return true;
 				}
 			}
-
-			if (this.isForbiddenToken(token)) {
-				return false;
-			}
 		}
 		return false;
 	}
@@ -88,7 +88,8 @@ export default class InlineBlock {
 			type === TokenType.RESERVED_LOGICAL_OPERATOR ||
 			// type === TokenType.LINE_COMMENT ||
 			type === TokenType.BLOCK_COMMENT ||
-			value === ';'
+			value === ';' ||
+			isToken.CASE({ type, value }) // CASE cannot have inline blocks
 		);
 	}
 }

--- a/src/core/Params.ts
+++ b/src/core/Params.ts
@@ -20,7 +20,7 @@ export default class Params {
 	/**
 	 * Returns param value that matches given placeholder with param key.
 	 * @param {Token} token
-	 * @return {String} param or token.value when params are missing
+	 * @return {string} param or token.value when params are missing
 	 */
 	get({ key, value }: Token): string {
 		if (!this.params) {

--- a/src/core/Tokenizer.ts
+++ b/src/core/Tokenizer.ts
@@ -83,7 +83,7 @@ export default class Tokenizer {
 			[TokenType.LINE_COMMENT]: regexFactory.createLineCommentRegex(cfg.lineCommentTypes),
 			[TokenType.BLOCK_COMMENT]: /^(\/\*[^]*?(?:\*\/|$))/u,
 			[TokenType.NUMBER]:
-				/^((-\s*)?[0-9]+(\.[0-9]+)?([eE][-+]?[0-9]+(\.[0-9]+)?)?|0x[0-9a-fA-F]+|0b[01]+)\b/u,
+				/^((-\s*)?[0-9]+(\.[0-9]*)?([eE][-+]?[0-9]+(\.[0-9]+)?)?|0x[0-9a-fA-F]+|0b[01]+)/u,
 			[TokenType.PLACEHOLDER]: NULL_REGEX, // matches nothing
 		};
 

--- a/src/core/Tokenizer.ts
+++ b/src/core/Tokenizer.ts
@@ -168,15 +168,18 @@ export default class Tokenizer {
 	 */
 	getPlaceholderToken(input: string): Token | undefined {
 		const placeholderTokenRegexMap: { regex: RegExp; parseKey: (s: string) => string }[] = [
+			// pattern for placeholder with identifier name
 			{
 				regex: this.IDENT_NAMED_PLACEHOLDER_REGEX ?? NULL_REGEX,
 				parseKey: v => v.slice(1),
 			},
+			// pattern for placeholder with string name
 			{
 				regex: this.STRING_NAMED_PLACEHOLDER_REGEX ?? NULL_REGEX,
 				parseKey: v =>
 					this.getEscapedPlaceholderKey({ key: v.slice(2, -1), quoteChar: v.slice(-1) }),
 			},
+			// pattern for placeholder with numeric index
 			{
 				regex: this.INDEXED_PLACEHOLDER_REGEX ?? NULL_REGEX,
 				parseKey: v => v.slice(1),
@@ -204,6 +207,7 @@ export default class Tokenizer {
 			return undefined;
 		}
 
+		// prioritised list of Reserved token types
 		const reservedTokenList = [
 			TokenType.RESERVED_COMMAND,
 			TokenType.RESERVED_BINARY_COMMAND,

--- a/src/core/Tokenizer.ts
+++ b/src/core/Tokenizer.ts
@@ -4,6 +4,7 @@ import { Token, TokenType } from './token'; // convert to partial type import in
 
 const NULL_REGEX = /(?!)/; // zero-width negative lookahead, matches nothing
 
+/** Struct that defines how a SQL language can be broken into tokens */
 interface TokenizerOptions {
 	reservedKeywords: string[];
 	reservedCommands: string[];
@@ -20,6 +21,7 @@ interface TokenizerOptions {
 	operators?: string[];
 }
 
+/** Converts SQL language string into a token stream */
 export default class Tokenizer {
 	WHITESPACE_REGEX: RegExp;
 	REGEX_MAP: { [tokenType in TokenType]: RegExp };
@@ -30,19 +32,19 @@ export default class Tokenizer {
 
 	/**
 	 * @param {TokenizerOptions} cfg
-	 *  @param {String[]} cfg.reservedKeywords: Reserved words in SQL
-	 *  @param {String[]} cfg.reservedDependentClauses: Words that following a specific Statement and must have data attached
-	 *  @param {String[]} cfg.reservedLogicalOperators: Words that are set to newline
-	 *  @param {String[]} cfg.reservedCommands: Words that are set to new line separately
-	 *  @param {String[]} cfg.reservedBinaryCommands: Words that are top level but have no indentation
-	 *  @param {String[]} cfg.stringTypes: String types to enable: "", '', ``, [], N''
-	 *  @param {String[]} cfg.blockStart: Opening parentheses to enable, like (, [
-	 *  @param {String[]} cfg.blockEnd: Closing parentheses to enable, like ), ]
-	 *  @param {String[]} cfg.indexedPlaceholderTypes: Prefixes for indexed placeholders, like ?
-	 *  @param {String[]} cfg.namedPlaceholderTypes: Prefixes for named placeholders, like @ and :
-	 *  @param {String[]} cfg.lineCommentTypes: Line comments to enable, like # and --
-	 *  @param {String[]} cfg.specialWordChars: Special chars that can be found inside of words, like @ and #
-	 *  @param {String[]} cfg.operators: Additional operators to recognize
+	 *  @param {string[]} cfg.reservedKeywords - Reserved words in SQL
+	 *  @param {string[]} cfg.reservedDependentClauses - Words that following a specific Statement and must have data attached
+	 *  @param {string[]} cfg.reservedLogicalOperators - Words that are set to newline
+	 *  @param {string[]} cfg.reservedCommands - Words that are set to new line separately
+	 *  @param {string[]} cfg.reservedBinaryCommands - Words that are top level but have no indentation
+	 *  @param {string[]} cfg.stringTypes - string types to enable - "", '', ``, [], N''
+	 *  @param {string[]} cfg.blockStart - Opening parentheses to enable, like (, [
+	 *  @param {string[]} cfg.blockEnd - Closing parentheses to enable, like ), ]
+	 *  @param {string[]} cfg.indexedPlaceholderTypes - Prefixes for indexed placeholders, like ?
+	 *  @param {string[]} cfg.namedPlaceholderTypes - Prefixes for named placeholders, like @ and :
+	 *  @param {string[]} cfg.lineCommentTypes - Line comments to enable, like # and --
+	 *  @param {string[]} cfg.specialWordChars - Special chars that can be found inside of words, like @ and #
+	 *  @param {string[]} cfg.operators - Additional operators to recognize
 	 */
 	constructor(cfg: TokenizerOptions) {
 		this.WHITESPACE_REGEX = /^(\s+)/u;
@@ -105,13 +107,10 @@ export default class Tokenizer {
 	 * Takes a SQL string and breaks it into tokens.
 	 * Each token is an object with type and value.
 	 *
-	 * @param {String} input The SQL string
-	 * @return {Token[]} tokens An array of tokens.
-	 *  @return {String} token.type
-	 *  @return {String} token.value
-	 *  @return {String} token.whitespaceBefore Preceding whitespace
+	 * @param {string} input - The SQL string
+	 * @returns {Token[]} output token stream
 	 */
-	tokenize(input: string) {
+	tokenize(input: string): Token[] {
 		const tokens: Token[] = [];
 		let token: Token | undefined;
 
@@ -133,18 +132,23 @@ export default class Tokenizer {
 		return tokens;
 	}
 
-	getWhitespace(input: string) {
+	/** Matches preceding whitespace if present */
+	getWhitespace(input: string): string {
 		const matches = input.match(this.WHITESPACE_REGEX);
 		return matches ? matches[1] : '';
 	}
 
-	matchToken = (tokenType: TokenType) => (input: string) =>
-		this.getTokenOnFirstMatch({
-			input,
-			type: tokenType,
-			regex: this.REGEX_MAP[tokenType],
-		});
+	/** Curried function of `getTokenOnFirstMatch` that allows token type to be passed first */
+	matchToken =
+		(tokenType: TokenType) =>
+		(input: string): Token | undefined =>
+			this.getTokenOnFirstMatch({
+				input,
+				type: tokenType,
+				regex: this.REGEX_MAP[tokenType],
+			});
 
+	/** Attempts to match next token from input string, tests RegExp patterns in decreasing priority */
 	getNextToken(input: string, previousToken?: Token) {
 		return (this.matchToken(TokenType.LINE_COMMENT)(input) ||
 			this.matchToken(TokenType.BLOCK_COMMENT)(input) ||
@@ -158,7 +162,11 @@ export default class Tokenizer {
 			this.matchToken(TokenType.OPERATOR)(input)) as Token;
 	}
 
-	getPlaceholderToken(input: string) {
+	/**
+	 * Attempts to match a placeholder token pattern
+	 * @return {Token | undefined} - The placeholder token if found, otherwise undefined
+	 */
+	getPlaceholderToken(input: string): Token | undefined {
 		const placeholderTokenRegexMap: { regex: RegExp; parseKey: (s: string) => string }[] = [
 			{
 				regex: this.IDENT_NAMED_PLACEHOLDER_REGEX ?? NULL_REGEX,
@@ -181,13 +189,17 @@ export default class Tokenizer {
 		}, undefined as Token | undefined);
 	}
 
-	getEscapedPlaceholderKey({ key, quoteChar }: { key: string; quoteChar: string }) {
+	getEscapedPlaceholderKey({ key, quoteChar }: { key: string; quoteChar: string }): string {
 		return key.replace(new RegExp(escapeRegExp('\\' + quoteChar), 'gu'), quoteChar);
 	}
 
-	getReservedWordToken(input: string, previousToken?: Token) {
+	/**
+	 * Attempts to match a Reserved word token pattern, avoiding edge cases of Reserved words within string tokens
+	 * @return {Token | undefined} - The Reserved word token if found, otherwise undefined
+	 */
+	getReservedWordToken(input: string, previousToken?: Token): Token | undefined {
 		// A reserved word cannot be preceded by a '.', '[', '`', or '"'
-		// this makes it so for "mytable.from", [from], `from`, "from" - from is not considered a reserved word
+		// this makes it so for "mytable.from", [from], `from`, "from" - from is not considered a Reserved word
 		if (previousToken && ['.', '[', '`', '"'].includes(previousToken.value)) {
 			return undefined;
 		}
@@ -206,7 +218,22 @@ export default class Tokenizer {
 		);
 	}
 
-	getTokenOnFirstMatch({ input, type, regex }: { input: string; type: TokenType; regex: RegExp }) {
+	/**
+	 * Attempts to match RegExp from head of input, returning undefined if not found
+	 * @param {string} _.input - The string to match
+	 * @param {TokenType} _.type - The type of token to match against
+	 * @param {RegExp} _.regex - The regex to match
+	 * @return {Token | undefined} - The matched token if found, otherwise undefined
+	 */
+	getTokenOnFirstMatch({
+		input,
+		type,
+		regex,
+	}: {
+		input: string;
+		type: TokenType;
+		regex: RegExp;
+	}): Token | undefined {
 		const matches = input.match(regex);
 		return matches ? ({ type, value: matches[1] } as Token) : undefined;
 	}

--- a/src/core/token.ts
+++ b/src/core/token.ts
@@ -35,6 +35,7 @@ export const isToken = {
 	AND: testToken({ value: 'AND', type: TokenType.RESERVED_LOGICAL_OPERATOR }),
 	BETWEEN: testToken({ value: 'BETWEEN', type: TokenType.RESERVED_KEYWORD }),
 	CASE: testToken({ value: 'CASE', type: TokenType.BLOCK_START }),
+	CAST: testToken({ value: 'CAST', type: TokenType.RESERVED_KEYWORD }),
 	BY: testToken({ value: 'BY', type: TokenType.RESERVED_KEYWORD }),
 	END: testToken({ value: 'END', type: TokenType.BLOCK_END }),
 	FROM: testToken({ value: 'FROM', type: TokenType.RESERVED_COMMAND }),

--- a/src/core/token.ts
+++ b/src/core/token.ts
@@ -42,7 +42,9 @@ export const isToken = {
 	LIMIT: testToken({ value: 'LIMIT', type: TokenType.RESERVED_COMMAND }),
 	SELECT: testToken({ value: 'SELECT', type: TokenType.RESERVED_COMMAND }),
 	SET: testToken({ value: 'SET', type: TokenType.RESERVED_COMMAND }),
+	TABLE: testToken({ value: 'TABLE', type: TokenType.RESERVED_KEYWORD }),
 	WINDOW: testToken({ value: 'WINDOW', type: TokenType.RESERVED_COMMAND }),
+	WITH: testToken({ value: 'WITH', type: TokenType.RESERVED_COMMAND }),
 };
 
 export const isCommand = (token: Token) =>

--- a/src/core/token.ts
+++ b/src/core/token.ts
@@ -1,3 +1,4 @@
+/** Token type enum for all possible Token categories */
 export enum TokenType {
 	WORD = 'WORD',
 	STRING = 'STRING',
@@ -15,6 +16,7 @@ export enum TokenType {
 	PLACEHOLDER = 'PLACEHOLDER',
 }
 
+/** Struct to store the most basic cohesive unit of language grammar */
 export interface Token {
 	value: string;
 	type: TokenType;
@@ -22,14 +24,19 @@ export interface Token {
 	whitespaceBefore?: string;
 }
 
+/** Special Unicode character to serve as a placeholder for TenSpace formats as \w whitespace is unavailable */
 export const ZWS = '​'; // uses zero-width space (&#8203; / U+200B)
 const ZWS_REGEX = '\u200b';
 const spaces = `[${ZWS_REGEX}\\s]`;
 
-export const testToken = (compareToken: Token) => (token: Token) =>
-	token?.type === compareToken.type &&
-	new RegExp(`^${spaces}*${compareToken.value}${spaces}*$`, 'iu').test(token?.value);
+/** Checks if two tokens are equivalent */
+export const testToken =
+	(compareToken: Token) =>
+	(token: Token): boolean =>
+		token?.type === compareToken.type &&
+		new RegExp(`^${spaces}*${compareToken.value}${spaces}*$`, 'iu').test(token?.value);
 
+/** Util object that allows for easy checking of Reserved Keywords */
 export const isToken = {
 	AS: testToken({ value: 'AS', type: TokenType.RESERVED_KEYWORD }),
 	AND: testToken({ value: 'AND', type: TokenType.RESERVED_LOGICAL_OPERATOR }),
@@ -48,11 +55,13 @@ export const isToken = {
 	WITH: testToken({ value: 'WITH', type: TokenType.RESERVED_COMMAND }),
 };
 
-export const isCommand = (token: Token) =>
+/** Checks if token is a Reserved Command or Reserved Binary Command */
+export const isCommand = (token: Token): boolean =>
 	token &&
 	(token.type === TokenType.RESERVED_COMMAND || token.type === TokenType.RESERVED_BINARY_COMMAND);
 
-export const isReserved = (token: Token) =>
+/** Checks if token is any Reserved Keyword or Command */
+export const isReserved = (token: Token): boolean =>
 	token &&
 	(token.type === TokenType.RESERVED_KEYWORD ||
 		token.type === TokenType.RESERVED_LOGICAL_OPERATOR ||

--- a/src/languages/bigquery.formatter.ts
+++ b/src/languages/bigquery.formatter.ts
@@ -1,7 +1,7 @@
 import Formatter from '../core/Formatter';
 import Tokenizer from '../core/Tokenizer';
 import type { StringPatternType } from '../core/regexFactory';
-import { Token, TokenType } from '../core/token';
+import { Token } from '../core/token';
 import { dedupe } from '../utils';
 
 /**
@@ -630,6 +630,7 @@ const reservedKeywords = {
 		// 'SET',
 		'SOME',
 		// 'STRUCT',
+		'TABLE',
 		// 'TABLESAMPLE',
 		// 'THEN',
 		'TO',

--- a/src/languages/hive.formatter.ts
+++ b/src/languages/hive.formatter.ts
@@ -479,7 +479,7 @@ const reservedKeywords = {
 		'ROW',
 		'ROWS',
 		// 'SELECT',
-		// 'SET',
+		'SET',
 		'SMALLINT',
 		'TABLE',
 		'TABLESAMPLE',
@@ -565,7 +565,7 @@ const reservedCommands = [
 	'OFFSET',
 	'ORDER BY',
 	'SELECT',
-	'SET',
+	// 'SET',
 	'SET SCHEMA', // added
 	'SHOW',
 	'SORT BY',

--- a/src/languages/plsql.formatter.ts
+++ b/src/languages/plsql.formatter.ts
@@ -42,6 +42,7 @@ const reservedKeywords = [
 	'CALL',
 	'CALLING',
 	'CASCADE',
+	'CAST',
 	'CHAR',
 	'CHARACTER',
 	'CHARSET',

--- a/src/sqlFormatter.ts
+++ b/src/sqlFormatter.ts
@@ -51,28 +51,28 @@ export interface FormatOptions {
 /**
  * Format whitespace in a query to make it easier to read.
  *
- * @param {String} query
+ * @param {string} query - input SQL query string
  * @param {FormatOptions} cfg
- *  @param {String} cfg.language Query language, default is Standard SQL
- *  @param {String} cfg.indent Characters used for indentation, default is "  " (2 spaces)
- *  @param {Boolean} cfg.uppercase Converts keywords to uppercase
- *  @param {KeywordMode} cfg.keywordPosition Sets main keyword position style, see keywordPosition.md for examples
- *  @param {NewlineMode} cfg.newline Determines when to break words onto a newline; always | never | lineWidth (break only when > line width) | number (break when > n)
- *  @param {Boolean} cfg.breakBeforeBooleanOperator Break before boolean operator (AND, OR, XOR) ?
- *  @param {AliasMode} cfg.aliasAs Whether to use AS in column aliases in only SELECT clause, both SELECT and table aliases, or never
- *  @param {Boolean} cfg.tabulateAlias Whether to have alias following clause or aligned to right
- *  @param {CommaPosition} cfg.commaPosition Where to place the comma in listed clauses
- *  @param {ParenOptions} cfg.parenOptions Various options for parentheses
- *  	@param {Boolean} cfg.parenOptions.openParenNewline Whether to place opening parenthesis on same line or newline
- *  	@param {Boolean} cfg.parenOptions.closeParenNewline Whether to place closing parenthesis on same line or newline
- *  //	@param {Boolean} cfg.parenOptions.reservedFunctionParens Whether to use parenthesis for reserved functions such as COUNT
- *  //	@param {Boolean} cfg.parenOptions.functionParenSpace Whether to add space before reserved function parens
- *  @param {Integer} cfg.lineWidth Number of characters in each line before breaking, default: 50
- *  @param {Integer} cfg.linesBetweenQueries How many line breaks between queries
- *  @param {Boolean} cfg.denseOperators whether to format operators with spaces
- *  @param {ParamItems} cfg.params Collection of params for placeholder replacement
- *  @param {Boolean} cfg.semicolonNewline Whether to place semicolon on newline
- * @return {String}
+ *  @param {string} cfg.language - Query language, default is Standard SQL
+ *  @param {string} cfg.indent - Characters used for indentation, default is "  " (2 spaces)
+ *  @param {Boolean} cfg.uppercase - Converts keywords to uppercase
+ *  @param {KeywordMode} cfg.keywordPosition - Sets main keyword position style, see keywordPosition.md for examples
+ *  @param {NewlineMode} cfg.newline - Determines when to break words onto a newline; always | never | lineWidth (break only when > line width) | number (break when > n)
+ *  @param {Boolean} cfg.breakBeforeBooleanOperator - Break before boolean operator (AND, OR, XOR) ?
+ *  @param {AliasMode} cfg.aliasAs - Whether to use AS in column aliases in only SELECT clause, both SELECT and table aliases, or never
+ *  @param {Boolean} cfg.tabulateAlias - Whether to have alias following clause or aligned to right
+ *  @param {CommaPosition} cfg.commaPosition - Where to place the comma in listed clauses
+ *  @param {ParenOptions} cfg.parenOptions - Various options for parentheses
+ *  	@param {Boolean} cfg.parenOptions -.openParenNewline Whether to place opening parenthesis on same line or newline
+ *  	@param {Boolean} cfg.parenOptions -.closeParenNewline Whether to place closing parenthesis on same line or newline
+ *  //	@param {Boolean} cfg.parenOptions -.reservedFunctionParens Whether to use parenthesis for reserved functions such as COUNT
+ *  //	@param {Boolean} cfg.parenOptions -.functionParenSpace Whether to add space before reserved function parens
+ *  @param {Integer} cfg.lineWidth - Number of characters in each line before breaking, default: 50
+ *  @param {Integer} cfg.linesBetweenQueries - How many line breaks between queries
+ *  @param {Boolean} cfg.denseOperators - whether to format operators with spaces
+ *  @param {ParamItems} cfg.params - Collection of params for placeholder replacement
+ *  @param {Boolean} cfg.semicolonNewline - Whether to place semicolon on newline
+ * @return {string} formatted query
  */
 export const format = (query: string, cfg: Partial<FormatOptions> = {}): string => {
 	if (typeof query !== 'string') {

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,21 +1,49 @@
+/**
+ * Enum for the different keyword formats
+ * @enum {string}
+ * @property {string} standard - Standard keyword format
+ * @property {string} tenSpaceLeft - Central aligned keyword format, keywords left-aligned
+ * @property {string} tenSpaceRight - Central aligned keyword format, keywords right-aligned
+ */
 export enum KeywordMode {
 	standard = 'standard',
 	tenSpaceLeft = 'tenSpaceLeft',
 	tenSpaceRight = 'tenSpaceRight',
 }
 
+/**
+ * Enum for the different newline modes
+ * @enum {string}
+ * @property {string} always - Always use newlines
+ * @property {string} never - Never use newlines
+ * @property {string} lineWidth - Use newlines when line width is greater than the specified number
+ */
 export enum NewlineMode {
 	always = 'always',
 	never = 'never',
 	lineWidth = 'lineWidth',
 }
 
+/**
+ * Enum for when to place AS for column aliases
+ * @enum {string}
+ * @property {string} always - Always use AS
+ * @property {string} never - Never use AS
+ * @property {string} select - Only use AS for SELECT clauses
+ */
 export enum AliasMode {
 	always = 'always',
 	never = 'never',
 	select = 'select',
 }
 
+/**
+ * Enum for when to place commas in listed clauses
+ * @enum {string}
+ * @property {string} after - Place after each item
+ * @property {string} before - Place before each item
+ * @property {string} tabular - Place commas at end of line, right-justified
+ */
 export enum CommaPosition {
 	before = 'before',
 	after = 'after',

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -19,9 +19,11 @@ export const sortByLengthDesc = (strings: string[]) =>
 		return b.length - a.length || a.localeCompare(b);
 	});
 
+/** Get length of longest string in list of strings */
 export const maxLength = (strings: string[]) =>
 	strings.reduce((max, cur) => Math.max(max, cur.length), 0);
 
+/** Make all strings in list the same length by appending spaces */
 export const tabulateLines = (...columns: string[][]) =>
 	columns.reduce((lines, cur) => {
 		const existingMaxLength = maxLength(lines);

--- a/static/index.html
+++ b/static/index.html
@@ -54,7 +54,9 @@
 							<option value="sql">SQL</option>
 							<!-- dialects -->
 							<option value="redshift">AWS Redshift</option>
+							<option value="bigquery">BigQuery</option>
 							<option value="db2">DB2</option>
+							<option value="hive">Hive</option>
 							<option value="mariadb">MariaDB</option>
 							<option value="mysql">MySQL</option>
 							<option value="n1ql">N1QL</option>

--- a/test/behavesLikeMariaDbFormatter.js
+++ b/test/behavesLikeMariaDbFormatter.js
@@ -9,15 +9,16 @@ import supportsJoin from './features/join';
 
 /**
  * Shared tests for MySQL and MariaDB
+ * @param {String} language
  * @param {Function} format
  */
-export default function behavesLikeMariaDbFormatter(format) {
-	behavesLikeSqlFormatter(format);
-	supportsCase(format);
-	supportsCreateTable(format);
-	supportsAlterTable(format);
-	supportsBetween(format);
-	supportsJoin(format, {
+export default function behavesLikeMariaDbFormatter(language, format) {
+	behavesLikeSqlFormatter(language, format);
+	supportsCase(language, format);
+	supportsCreateTable(language, format);
+	supportsAlterTable(language, format);
+	supportsBetween(language, format);
+	supportsJoin(language, format, {
 		without: ['FULL'],
 		additionally: [
 			'STRAIGHT_JOIN',

--- a/test/behavesLikeMariaDbFormatter.js
+++ b/test/behavesLikeMariaDbFormatter.js
@@ -9,7 +9,7 @@ import supportsJoin from './features/join';
 
 /**
  * Shared tests for MySQL and MariaDB
- * @param {String} language
+ * @param {string} language
  * @param {Function} format
  */
 export default function behavesLikeMariaDbFormatter(language, format) {

--- a/test/behavesLikeSqlFormatter.js
+++ b/test/behavesLikeSqlFormatter.js
@@ -11,7 +11,7 @@ import { itIf } from './utils';
 
 /**
  * Core tests for all SQL formatters
- * @param {String} language
+ * @param {string} language
  * @param {Function} format
  */
 export default function behavesLikeSqlFormatter(language, format) {

--- a/test/behavesLikeSqlFormatter.js
+++ b/test/behavesLikeSqlFormatter.js
@@ -121,7 +121,7 @@ export default function behavesLikeSqlFormatter(format) {
 		expect(result).toBe(dedent`
       LIMIT
         5;
-      
+
       SELECT
         foo,
         bar;
@@ -378,7 +378,7 @@ export default function behavesLikeSqlFormatter(format) {
         Column1
       FROM
         Table1;
-      
+
       SELECT
         COUNT(*),
         Column1
@@ -408,7 +408,7 @@ export default function behavesLikeSqlFormatter(format) {
         *
       FROM
         test;
-      
+
       CREATE TABLE
         test(
           id NUMBER NOT NULL,
@@ -427,6 +427,22 @@ export default function behavesLikeSqlFormatter(format) {
         3.5E12 AS c,
         3.5e12 AS d;
     `);
+	});
+
+	it('correctly handles floats with trailing point', () => {
+		let result = format('SELECT 1000. AS a;');
+		expect(result).toBe(dedent`
+		  SELECT
+		    1000. AS a;
+		`);
+
+		result = format('SELECT a, b / 1000. AS a_s, 100. * b / SUM(a_s);');
+		expect(result).toBe(dedent`
+		  SELECT
+        a,
+        b / 1000. AS a_s,
+        100.* b / SUM(a_s);
+		`);
 	});
 
 	it('does not split UNION ALL in half', () => {

--- a/test/behavesLikeSqlFormatter.js
+++ b/test/behavesLikeSqlFormatter.js
@@ -439,10 +439,10 @@ export default function behavesLikeSqlFormatter(format) {
 		result = format('SELECT a, b / 1000. AS a_s, 100. * b / SUM(a_s);');
 		expect(result).toBe(dedent`
 		  SELECT
-        a,
-        b / 1000. AS a_s,
-        100.* b / SUM(a_s);
-		`);
+		    a,
+		    b / 1000. AS a_s,
+		    100. * b / SUM(a_s);
+	  `);
 	});
 
 	it('does not split UNION ALL in half', () => {

--- a/test/behavesLikeSqlFormatter.js
+++ b/test/behavesLikeSqlFormatter.js
@@ -7,17 +7,20 @@ import supportsNewlineOptions from './features/newline';
 import supportsKeywordPositions from './features/keywordPosition';
 import supportsParenthesesOptions from './features/parenthesis';
 
+import { itIf } from './utils';
+
 /**
  * Core tests for all SQL formatters
+ * @param {String} language
  * @param {Function} format
  */
-export default function behavesLikeSqlFormatter(format) {
-	supportsAliases(format);
-	supportsComments(format);
-	supportsConfigOptions(format);
-	supportsKeywordPositions(format);
-	supportsNewlineOptions(format);
-	supportsParenthesesOptions(format);
+export default function behavesLikeSqlFormatter(language, format) {
+	supportsAliases(language, format);
+	supportsComments(language, format);
+	supportsConfigOptions(language, format);
+	supportsKeywordPositions(language, format);
+	supportsNewlineOptions(language, format);
+	supportsParenthesesOptions(language, format);
 
 	it('does nothing with empty input', () => {
 		const result = format('');
@@ -256,7 +259,7 @@ export default function behavesLikeSqlFormatter(format) {
     `);
 	});
 
-	it('formats simple UPDATE query', () => {
+	itIf(language !== 'hive')('formats simple UPDATE query', () => {
 		const result = format(
 			"UPDATE Customers SET ContactName='Alfred Schmidt', City='Hamburg' WHERE CustomerName='Alfreds Futterkiste';"
 		);
@@ -299,7 +302,7 @@ export default function behavesLikeSqlFormatter(format) {
     `);
 	});
 
-	it('formats UPDATE query with AS part', () => {
+	itIf(language !== 'hive')('formats UPDATE query with AS part', () => {
 		const result = format(
 			'UPDATE customers SET total_orders = order_summary.total  FROM ( SELECT * FROM bank) AS order_summary',
 			{ aliasAs: 'always' }

--- a/test/bigquery.test.js
+++ b/test/bigquery.test.js
@@ -13,17 +13,19 @@ import supportsJoin from './features/join';
 import supportsOperators from './features/operators';
 
 describe('BigQueryFormatter', () => {
-	const format = (query, cfg = {}) => sqlFormatter.format(query, { ...cfg, language: 'bigquery' });
+	const language = 'bigquery';
+	const format = (query, cfg = {}) => sqlFormatter.format(query, { ...cfg, language });
 
-	behavesLikeSqlFormatter(format);
-	supportsCase(format);
-	supportsCreateTable(format);
-	supportsAlterTable(format);
-	supportsStrings(format, BigQueryFormatter.stringTypes);
-	supportsBetween(format);
-	supportsSchema(format);
-	supportsJoin(format, { without: ['NATURAL JOIN'] });
+	behavesLikeSqlFormatter(language, format);
+	supportsCase(language, format);
+	supportsCreateTable(language, format);
+	supportsAlterTable(language, format);
+	supportsStrings(language, format, BigQueryFormatter.stringTypes);
+	supportsBetween(language, format);
+	supportsSchema(language, format);
+	supportsJoin(language, format, { without: ['NATURAL JOIN'] });
 	supportsOperators(
+		language,
 		format,
 		BigQueryFormatter.operators,
 		BigQueryFormatter.reservedLogicalOperators

--- a/test/db2.test.js
+++ b/test/db2.test.js
@@ -12,16 +12,22 @@ import supportsSchema from './features/schema';
 import supportsStrings from './features/strings';
 
 describe('Db2Formatter', () => {
-	const format = (query, cfg = {}) => sqlFormatter.format(query, { ...cfg, language: 'db2' });
+	const language = 'db2';
+	const format = (query, cfg = {}) => sqlFormatter.format(query, { ...cfg, language });
 
-	behavesLikeSqlFormatter(format);
-	supportsCreateTable(format);
-	supportsAlterTable(format);
-	supportsStrings(format, Db2Formatter.stringTypes);
-	supportsBetween(format);
-	supportsSchema(format);
-	supportsOperators(format, Db2Formatter.operators, Db2Formatter.reservedLogicalOperators);
-	supportsJoin(format);
+	behavesLikeSqlFormatter(language, format);
+	supportsCreateTable(language, format);
+	supportsAlterTable(language, format);
+	supportsStrings(language, format, Db2Formatter.stringTypes);
+	supportsBetween(language, format);
+	supportsSchema(language, format);
+	supportsOperators(
+		language,
+		format,
+		Db2Formatter.operators,
+		Db2Formatter.reservedLogicalOperators
+	);
+	supportsJoin(language, format);
 
 	it('formats FETCH FIRST like LIMIT', () => {
 		expect(format('SELECT col1 FROM tbl ORDER BY col2 DESC FETCH FIRST 20 ROWS ONLY;')).toBe(dedent`

--- a/test/features/alias.js
+++ b/test/features/alias.js
@@ -213,4 +213,19 @@ export default function supportsAliases(format) {
         )
 		`);
 	});
+
+	it('handles edge case of never + CAST', () => {
+		const result = format(
+			dedent`SELECT
+			CAST(0 AS bit),
+			'foo' AS bar`,
+			{ aliasAs: 'never' }
+		);
+
+		expect(result).toBe(dedent`
+      SELECT
+        CAST(0 AS bit),
+        'foo' bar
+		`);
+	});
 }

--- a/test/features/alias.js
+++ b/test/features/alias.js
@@ -3,9 +3,10 @@ import { NewlineMode } from '../../src/types';
 
 /**
  * Tests support for alias options
+ * @param {String} language
  * @param {Function} format
  */
-export default function supportsAliases(format) {
+export default function supportsAliases(language, format) {
 	const baseQuery = 'SELECT a a_column, b AS bColumn FROM ( SELECT * FROM x ) y WHERE z;';
 
 	it('supports always mode', () => {

--- a/test/features/alias.js
+++ b/test/features/alias.js
@@ -196,4 +196,21 @@ export default function supportsAliases(format) {
 			].join('\n')
 		);
 	});
+
+	it('handles edge case of never + CTE', () => {
+		const result = format(
+			dedent`CREATE TABLE 'test.example_table' AS WITH cte AS (SELECT a AS alpha)`,
+			{ aliasAs: 'never' }
+		);
+
+		expect(result).toBe(dedent`
+      CREATE TABLE
+        'test.example_table' AS
+      WITH
+        cte AS (
+          SELECT
+            a alpha
+        )
+		`);
+	});
 }

--- a/test/features/alias.js
+++ b/test/features/alias.js
@@ -3,7 +3,7 @@ import { NewlineMode } from '../../src/types';
 
 /**
  * Tests support for alias options
- * @param {String} language
+ * @param {string} language
  * @param {Function} format
  */
 export default function supportsAliases(language, format) {

--- a/test/features/alias.js
+++ b/test/features/alias.js
@@ -217,14 +217,14 @@ export default function supportsAliases(format) {
 	it('handles edge case of never + CAST', () => {
 		const result = format(
 			dedent`SELECT
-			CAST(0 AS bit),
+			CAST(0 AS BIT),
 			'foo' AS bar`,
 			{ aliasAs: 'never' }
 		);
 
 		expect(result).toBe(dedent`
       SELECT
-        CAST(0 AS bit),
+        CAST(0 AS BIT),
         'foo' bar
 		`);
 	});

--- a/test/features/alterTable.js
+++ b/test/features/alterTable.js
@@ -1,12 +1,14 @@
 import dedent from 'dedent-js';
 
+import { itIf } from '../utils';
+
 /**
  * Tests support for ALTER TABLE syntax
+ * @param {String} language
  * @param {Function} format
  */
-export default function supportsAlterTable(format) {
-	// current breaks on BigQuery
-	it.skip('formats ALTER TABLE ... ALTER COLUMN query', () => {
+export default function supportsAlterTable(language, format) {
+	itIf(language !== 'bigquery')('formats ALTER TABLE ... ALTER COLUMN query', () => {
 		const result = format('ALTER TABLE supplier ALTER COLUMN supplier_name VARCHAR(100) NOT NULL;');
 		expect(result).toBe(dedent`
       ALTER TABLE

--- a/test/features/alterTable.js
+++ b/test/features/alterTable.js
@@ -4,7 +4,7 @@ import { itIf } from '../utils';
 
 /**
  * Tests support for ALTER TABLE syntax
- * @param {String} language
+ * @param {string} language
  * @param {Function} format
  */
 export default function supportsAlterTable(language, format) {

--- a/test/features/alterTableModify.js
+++ b/test/features/alterTableModify.js
@@ -2,9 +2,10 @@ import dedent from 'dedent-js';
 
 /**
  * Tests support for ALTER TABLE ... MODIFY syntax
+ * @param {String} language
  * @param {Function} format
  */
-export default function supportsAlterTableModify(format) {
+export default function supportsAlterTableModify(language, format) {
 	it('formats ALTER TABLE ... MODIFY statement', () => {
 		const result = format('ALTER TABLE supplier MODIFY supplier_name char(100) NOT NULL;');
 		expect(result).toBe(dedent`

--- a/test/features/alterTableModify.js
+++ b/test/features/alterTableModify.js
@@ -2,7 +2,7 @@ import dedent from 'dedent-js';
 
 /**
  * Tests support for ALTER TABLE ... MODIFY syntax
- * @param {String} language
+ * @param {string} language
  * @param {Function} format
  */
 export default function supportsAlterTableModify(language, format) {

--- a/test/features/between.js
+++ b/test/features/between.js
@@ -1,8 +1,9 @@
 /**
  * Tests support for BETWEEN _ AND _ syntax
+ * @param {String} language
  * @param {Function} format
  */
-export default function supportsBetween(format) {
+export default function supportsBetween(language, format) {
 	it('formats BETWEEN _ AND _ on single line', () => {
 		expect(format('foo BETWEEN bar AND baz')).toBe('foo BETWEEN bar AND baz');
 	});

--- a/test/features/between.js
+++ b/test/features/between.js
@@ -1,6 +1,6 @@
 /**
  * Tests support for BETWEEN _ AND _ syntax
- * @param {String} language
+ * @param {string} language
  * @param {Function} format
  */
 export default function supportsBetween(language, format) {

--- a/test/features/case.js
+++ b/test/features/case.js
@@ -2,9 +2,10 @@ import dedent from 'dedent-js';
 
 /**
  * Tests support for CASE [WHEN...] END syntax
+ * @param {String} language
  * @param {Function} format
  */
-export default function supportsCase(format) {
+export default function supportsCase(language, format) {
 	it('formats CASE ... WHEN with a blank expression', () => {
 		const result = format(
 			"CASE WHEN [option] = 'foo' THEN 1 WHEN [option] = 'bar' THEN 2 WHEN [option] = 'baz' THEN 3 ELSE 4 END;"

--- a/test/features/case.js
+++ b/test/features/case.js
@@ -108,4 +108,18 @@ export default function supportsCase(format) {
       END;
     `);
 	});
+
+	it('handles edge case of ending inline block with END', () => {
+		const result = format(dedent`select sum(case a when foo then bar end) from quaz`);
+
+		expect(result).toBe(dedent`
+      SELECT
+        SUM(CASE a
+        WHEN foo
+        THEN bar END
+      )
+      FROM
+        quaz
+		`);
+	});
 }

--- a/test/features/case.js
+++ b/test/features/case.js
@@ -2,7 +2,7 @@ import dedent from 'dedent-js';
 
 /**
  * Tests support for CASE [WHEN...] END syntax
- * @param {String} language
+ * @param {string} language
  * @param {Function} format
  */
 export default function supportsCase(language, format) {

--- a/test/features/case.js
+++ b/test/features/case.js
@@ -110,16 +110,19 @@ export default function supportsCase(format) {
 	});
 
 	it('handles edge case of ending inline block with END', () => {
-		const result = format(dedent`select sum(case a when foo then bar end) from quaz`);
+		const result = format(dedent`select sum(case a when foo then bar end) from quaz`, {
+			newline: 1,
+		});
 
 		expect(result).toBe(dedent`
       SELECT
-        SUM(CASE a
-        WHEN foo
-        THEN bar END
-      )
-      FROM
-        quaz
-		`);
+        SUM(
+          CASE a
+            WHEN foo
+            THEN bar
+          END
+        )
+      FROM quaz
+    `);
 	});
 }

--- a/test/features/comma.js
+++ b/test/features/comma.js
@@ -2,9 +2,10 @@ import dedent from 'dedent-js';
 
 /**
  * Tests support for alias options
+ * @param {String} language
  * @param {Function} format
  */
-export default function supportsCommaModes(format) {
+export default function supportsCommaModes(language, format) {
 	it('supports comma after column', () => {
 		const result = format(
 			'SELECT alpha, MAX(beta), delta AS d, epsilon FROM gamma GROUP BY alpha, delta, epsilon'

--- a/test/features/comma.js
+++ b/test/features/comma.js
@@ -2,7 +2,7 @@ import dedent from 'dedent-js';
 
 /**
  * Tests support for alias options
- * @param {String} language
+ * @param {string} language
  * @param {Function} format
  */
 export default function supportsCommaModes(language, format) {

--- a/test/features/comments.js
+++ b/test/features/comments.js
@@ -1,10 +1,13 @@
 import dedent from 'dedent-js';
 
+import { itIf } from '../utils';
+
 /**
  * Tests for standard -- and /* *\/ comments
+ * @param {String} language
  * @param {Function} format
  */
-export default function supportsComments(format) {
+export default function supportsComments(language, format) {
 	it('formats SELECT query with different comments', () => {
 		const result = format(dedent`
       SELECT
@@ -45,8 +48,7 @@ export default function supportsComments(format) {
 		expect(format(sql)).toBe(sql);
 	});
 
-	// currently breaks on BigQuery
-	it.skip('formats tricky line comments', () => {
+	itIf(language != 'bigquery')('formats tricky line comments', () => {
 		expect(format('SELECT a--comment, here\nFROM b--comment')).toBe(dedent`
       SELECT
         a --comment, here

--- a/test/features/comments.js
+++ b/test/features/comments.js
@@ -4,7 +4,7 @@ import { itIf } from '../utils';
 
 /**
  * Tests for standard -- and /* *\/ comments
- * @param {String} language
+ * @param {string} language
  * @param {Function} format
  */
 export default function supportsComments(language, format) {

--- a/test/features/configOptions.js
+++ b/test/features/configOptions.js
@@ -2,7 +2,7 @@ import dedent from 'dedent-js';
 
 /**
  * Tests for all the config options
- * @param {String} language
+ * @param {string} language
  * @param {Function} format
  */
 export default function supportsConfigOptions(language, format) {

--- a/test/features/configOptions.js
+++ b/test/features/configOptions.js
@@ -2,9 +2,10 @@ import dedent from 'dedent-js';
 
 /**
  * Tests for all the config options
+ * @param {String} language
  * @param {Function} format
  */
-export default function supportsConfigOptions(format) {
+export default function supportsConfigOptions(language, format) {
 	it('supports indent option', () => {
 		const result = format('SELECT count(*),Column1 FROM Table1;', {
 			indent: '    ',

--- a/test/features/createTable.js
+++ b/test/features/createTable.js
@@ -3,7 +3,7 @@ import { NewlineMode } from '../../src/types';
 
 /**
  * Tests support for CREATE TABLE syntax
- * @param {String} language
+ * @param {string} language
  * @param {Function} format
  */
 export default function supportsCreateTable(language, format) {

--- a/test/features/createTable.js
+++ b/test/features/createTable.js
@@ -3,9 +3,10 @@ import { NewlineMode } from '../../src/types';
 
 /**
  * Tests support for CREATE TABLE syntax
+ * @param {String} language
  * @param {Function} format
  */
-export default function supportsCreateTable(format) {
+export default function supportsCreateTable(language, format) {
 	it('formats short CREATE TABLE', () => {
 		expect(
 			format('CREATE TABLE tbl (a INT PRIMARY KEY, b TEXT);', {

--- a/test/features/join.js
+++ b/test/features/join.js
@@ -2,12 +2,13 @@ import dedent from 'dedent-js';
 
 /**
  * Tests support for various joins
+ * @param {String} language
  * @param {Function} format
  * @param {Object} opts
  * @param {String[]} opts.without
  * @param {String[]} opts.additionally
  */
-export default function supportsJoin(format, { without, additionally } = {}) {
+export default function supportsJoin(language, format, { without, additionally } = {}) {
 	const unsupportedJoinRegex = without ? new RegExp(without.join('|'), 'u') : /^whateve_!%&$/u;
 	const isSupportedJoin = join => !unsupportedJoinRegex.test(join);
 

--- a/test/features/join.js
+++ b/test/features/join.js
@@ -2,11 +2,11 @@ import dedent from 'dedent-js';
 
 /**
  * Tests support for various joins
- * @param {String} language
+ * @param {string} language
  * @param {Function} format
  * @param {Object} opts
- * @param {String[]} opts.without
- * @param {String[]} opts.additionally
+ * @param {string[]} opts.without
+ * @param {string[]} opts.additionally
  */
 export default function supportsJoin(language, format, { without, additionally } = {}) {
 	const unsupportedJoinRegex = without ? new RegExp(without.join('|'), 'u') : /^whateve_!%&$/u;

--- a/test/features/keywordPosition.js
+++ b/test/features/keywordPosition.js
@@ -2,9 +2,10 @@ import dedent from 'dedent-js';
 
 /**
  * Tests support for keyword positions
+ * @param {String} language
  * @param {Function} format
  */
-export default function supportsKeywordPositions(format) {
+export default function supportsKeywordPositions(language, format) {
 	const baseQuery = `
 		SELECT COUNT(a.column1), MAX(b.column2 + b.column3), b.column4 AS four
 		FROM ( SELECT column1, column5 FROM table1 ) a

--- a/test/features/keywordPosition.js
+++ b/test/features/keywordPosition.js
@@ -2,7 +2,7 @@ import dedent from 'dedent-js';
 
 /**
  * Tests support for keyword positions
- * @param {String} language
+ * @param {string} language
  * @param {Function} format
  */
 export default function supportsKeywordPositions(language, format) {

--- a/test/features/newline.js
+++ b/test/features/newline.js
@@ -2,7 +2,7 @@ import dedent from 'dedent-js';
 
 /**
  * Tests support for all newline options
- * @param {String} language
+ * @param {string} language
  * @param {Function} format
  */
 export default function supportsNewlineOptions(language, format) {

--- a/test/features/newline.js
+++ b/test/features/newline.js
@@ -2,9 +2,10 @@ import dedent from 'dedent-js';
 
 /**
  * Tests support for all newline options
+ * @param {String} language
  * @param {Function} format
  */
-export default function supportsNewlineOptions(format) {
+export default function supportsNewlineOptions(language, format) {
 	it('supports always mode', () => {
 		const result = format('SELECT foo, bar, baz FROM qux;', {
 			newline: 'always',

--- a/test/features/operators.js
+++ b/test/features/operators.js
@@ -2,9 +2,9 @@ import dedent from 'dedent-js';
 
 /**
  * Tests support for various operators
- * @param {String} language
+ * @param {string} language
  * @param {Function} format
- * @param {String[]} operators
+ * @param {string[]} operators
  */
 export default function supportsOperators(language, format, operators = [], logicalOperators = []) {
 	operators.forEach(op => {

--- a/test/features/operators.js
+++ b/test/features/operators.js
@@ -2,10 +2,11 @@ import dedent from 'dedent-js';
 
 /**
  * Tests support for various operators
+ * @param {String} language
  * @param {Function} format
  * @param {String[]} operators
  */
-export default function supportsOperators(format, operators = [], logicalOperators = []) {
+export default function supportsOperators(language, format, operators = [], logicalOperators = []) {
 	operators.forEach(op => {
 		it(`supports ${op} operator`, () => {
 			expect(format(`foo${op}bar`)).toBe(`foo ${op} bar`);

--- a/test/features/parenthesis.js
+++ b/test/features/parenthesis.js
@@ -2,7 +2,7 @@ import dedent from 'dedent-js';
 
 /**
  * Tests support for all newline options
- * @param {String} language
+ * @param {string} language
  * @param {Function} format
  */
 export default function supportsParenthesesOptions(language, format) {

--- a/test/features/parenthesis.js
+++ b/test/features/parenthesis.js
@@ -2,9 +2,10 @@ import dedent from 'dedent-js';
 
 /**
  * Tests support for all newline options
+ * @param {String} language
  * @param {Function} format
  */
-export default function supportsParenthesesOptions(format) {
+export default function supportsParenthesesOptions(language, format) {
 	it('supports opening parenthesis on newline', () => {
 		const result = format('SELECT a FROM ( SELECT b FROM c );');
 		expect(result).toBe(dedent`

--- a/test/features/schema.js
+++ b/test/features/schema.js
@@ -2,9 +2,10 @@ import dedent from 'dedent-js';
 
 /**
  * Tests support for SET SCHEMA syntax
+ * @param {String} language
  * @param {Function} format
  */
-export default function supportsSchema(format) {
+export default function supportsSchema(language, format) {
 	it('formats simple SET SCHEMA statements', () => {
 		const result = format('SET SCHEMA schema1;');
 		expect(result).toBe(dedent`

--- a/test/features/schema.js
+++ b/test/features/schema.js
@@ -2,7 +2,7 @@ import dedent from 'dedent-js';
 
 /**
  * Tests support for SET SCHEMA syntax
- * @param {String} language
+ * @param {string} language
  * @param {Function} format
  */
 export default function supportsSchema(language, format) {

--- a/test/features/strings.js
+++ b/test/features/strings.js
@@ -1,9 +1,10 @@
 /**
  * Tests support for various string syntax
+ * @param {String} language
  * @param {Function} format
  * @param {String[]} stringTypes
  */
-export default function supportsStrings(format, stringTypes = []) {
+export default function supportsStrings(language, format, stringTypes = []) {
 	if (stringTypes.includes('""')) {
 		it('supports double-quoted strings', () => {
 			expect(format('"foo JOIN bar"')).toBe('"foo JOIN bar"');

--- a/test/features/strings.js
+++ b/test/features/strings.js
@@ -1,8 +1,8 @@
 /**
  * Tests support for various string syntax
- * @param {String} language
+ * @param {string} language
  * @param {Function} format
- * @param {String[]} stringTypes
+ * @param {string[]} stringTypes
  */
 export default function supportsStrings(language, format, stringTypes = []) {
 	if (stringTypes.includes('""')) {

--- a/test/hive.test.js
+++ b/test/hive.test.js
@@ -1,4 +1,3 @@
-import dedent from 'dedent-js';
 import * as sqlFormatter from '../src/sqlFormatter';
 import HiveFormatter from '../src/languages/hive.formatter';
 import behavesLikeSqlFormatter from './behavesLikeSqlFormatter';
@@ -13,15 +12,21 @@ import supportsJoin from './features/join';
 import supportsOperators from './features/operators';
 
 describe('HiveFormatter', () => {
-	const format = (query, cfg = {}) => sqlFormatter.format(query, { ...cfg, language: 'hive' });
+	const language = 'hive';
+	const format = (query, cfg = {}) => sqlFormatter.format(query, { ...cfg, language });
 
-	behavesLikeSqlFormatter(format);
-	supportsCase(format);
-	supportsCreateTable(format);
-	supportsAlterTable(format);
-	supportsStrings(format, HiveFormatter.stringTypes);
-	supportsBetween(format);
-	supportsSchema(format);
-	supportsJoin(format, { without: ['NATURAL JOIN'] });
-	supportsOperators(format, HiveFormatter.operators, HiveFormatter.reservedLogicalOperators);
+	behavesLikeSqlFormatter(language, format);
+	supportsCase(language, format);
+	supportsCreateTable(language, format);
+	supportsAlterTable(language, format);
+	supportsStrings(language, format, HiveFormatter.stringTypes);
+	supportsBetween(language, format);
+	supportsSchema(language, format);
+	supportsJoin(language, format, { without: ['NATURAL JOIN'] });
+	supportsOperators(
+		language,
+		format,
+		HiveFormatter.operators,
+		HiveFormatter.reservedLogicalOperators
+	);
 });

--- a/test/mariadb.test.js
+++ b/test/mariadb.test.js
@@ -6,10 +6,16 @@ import supportsStrings from './features/strings';
 import supportsOperators from './features/operators';
 
 describe('MariaDbFormatter', () => {
-	const format = (query, cfg = {}) => sqlFormatter.format(query, { ...cfg, language: 'mariadb' });
+	const language = 'mariadb';
+	const format = (query, cfg = {}) => sqlFormatter.format(query, { ...cfg, language });
 
-	behavesLikeMariaDbFormatter(format);
+	behavesLikeMariaDbFormatter(language, format);
 
-	supportsStrings(format, MariaDbFormatter.stringTypes);
-	supportsOperators(format, MariaDbFormatter.operators, MariaDbFormatter.reservedLogicalOperators);
+	supportsStrings(language, format, MariaDbFormatter.stringTypes);
+	supportsOperators(
+		language,
+		format,
+		MariaDbFormatter.operators,
+		MariaDbFormatter.reservedLogicalOperators
+	);
 });

--- a/test/mysql.test.js
+++ b/test/mysql.test.js
@@ -7,12 +7,18 @@ import supportsStrings from './features/strings';
 import supportsOperators from './features/operators';
 
 describe('MySqlFormatter', () => {
-	const format = (query, cfg = {}) => sqlFormatter.format(query, { ...cfg, language: 'mysql' });
+	const language = 'mysql';
+	const format = (query, cfg = {}) => sqlFormatter.format(query, { ...cfg, language });
 
-	behavesLikeMariaDbFormatter(format);
+	behavesLikeMariaDbFormatter(language, format);
 
-	supportsStrings(format, MySqlFormatter.stringTypes);
-	supportsOperators(format, MySqlFormatter.operators, MySqlFormatter.reservedLogicalOperators);
+	supportsStrings(language, format, MySqlFormatter.stringTypes);
+	supportsOperators(
+		language,
+		format,
+		MySqlFormatter.operators,
+		MySqlFormatter.reservedLogicalOperators
+	);
 
 	it('supports @@ system variables', () => {
 		const result = format('SELECT @@GLOBAL.time, @@SYSTEM.date, @@hour FROM foo;');

--- a/test/n1ql.test.js
+++ b/test/n1ql.test.js
@@ -10,14 +10,20 @@ import supportsSchema from './features/schema';
 import supportsStrings from './features/strings';
 
 describe('N1qlFormatter', () => {
-	const format = (query, cfg = {}) => sqlFormatter.format(query, { ...cfg, language: 'n1ql' });
+	const language = 'n1ql';
+	const format = (query, cfg = {}) => sqlFormatter.format(query, { ...cfg, language });
 
-	behavesLikeSqlFormatter(format);
-	supportsStrings(format, N1qlFormatter.stringTypes);
-	supportsBetween(format);
-	supportsSchema(format);
-	supportsOperators(format, N1qlFormatter.operators, N1qlFormatter.reservedLogicalOperators);
-	supportsJoin(format, { without: ['FULL', 'CROSS', 'NATURAL'] });
+	behavesLikeSqlFormatter(language, format);
+	supportsStrings(language, format, N1qlFormatter.stringTypes);
+	supportsBetween(language, format);
+	supportsSchema(language, format);
+	supportsOperators(
+		language,
+		format,
+		N1qlFormatter.operators,
+		N1qlFormatter.reservedLogicalOperators
+	);
+	supportsJoin(language, format, { without: ['FULL', 'CROSS', 'NATURAL'] });
 
 	it('formats SELECT query with element selection expression', () => {
 		const result = format('SELECT order_lines[0].productId FROM orders;');

--- a/test/plsql.test.js
+++ b/test/plsql.test.js
@@ -14,18 +14,24 @@ import supportsSchema from './features/schema';
 import supportsStrings from './features/strings';
 
 describe('PlSqlFormatter', () => {
-	const format = (query, cfg = {}) => sqlFormatter.format(query, { ...cfg, language: 'plsql' });
+	const language = 'plsql';
+	const format = (query, cfg = {}) => sqlFormatter.format(query, { ...cfg, language });
 
-	behavesLikeSqlFormatter(format);
-	supportsCase(format);
-	supportsCreateTable(format);
-	supportsAlterTable(format);
-	supportsAlterTableModify(format);
-	supportsStrings(format, PlSqlFormatter.stringTypes);
-	supportsBetween(format);
-	supportsSchema(format);
-	supportsOperators(format, PlSqlFormatter.operators, PlSqlFormatter.reservedLogicalOperators);
-	supportsJoin(format);
+	behavesLikeSqlFormatter(language, format);
+	supportsCase(language, format);
+	supportsCreateTable(language, format);
+	supportsAlterTable(language, format);
+	supportsAlterTableModify(language, format);
+	supportsStrings(language, format, PlSqlFormatter.stringTypes);
+	supportsBetween(language, format);
+	supportsSchema(language, format);
+	supportsOperators(
+		language,
+		format,
+		PlSqlFormatter.operators,
+		PlSqlFormatter.reservedLogicalOperators
+	);
+	supportsJoin(language, format);
 
 	it('formats FETCH FIRST like LIMIT', () => {
 		expect(format('SELECT col1 FROM tbl ORDER BY col2 DESC FETCH FIRST 20 ROWS ONLY;')).toBe(dedent`

--- a/test/postgresql.test.js
+++ b/test/postgresql.test.js
@@ -13,22 +13,23 @@ import supportsSchema from './features/schema';
 import supportsStrings from './features/strings';
 
 describe('PostgreSqlFormatter', () => {
-	const format = (query, cfg = {}) =>
-		sqlFormatter.format(query, { ...cfg, language: 'postgresql' });
+	const language = 'postgresql';
+	const format = (query, cfg = {}) => sqlFormatter.format(query, { ...cfg, language });
 
-	behavesLikeSqlFormatter(format);
-	supportsCase(format);
-	supportsCreateTable(format);
-	supportsAlterTable(format);
-	supportsStrings(format, PostgreSqlFormatter.stringTypes);
-	supportsBetween(format);
-	supportsSchema(format);
+	behavesLikeSqlFormatter(language, format);
+	supportsCase(language, format);
+	supportsCreateTable(language, format);
+	supportsAlterTable(language, format);
+	supportsStrings(language, format, PostgreSqlFormatter.stringTypes);
+	supportsBetween(language, format);
+	supportsSchema(language, format);
 	supportsOperators(
+		language,
 		format,
 		PostgreSqlFormatter.operators,
 		PostgreSqlFormatter.reservedLogicalOperators
 	);
-	supportsJoin(format);
+	supportsJoin(language, format);
 
 	it('supports $n placeholders', () => {
 		const result = format('SELECT $1, $2 FROM tbl');

--- a/test/redshift.test.js
+++ b/test/redshift.test.js
@@ -12,20 +12,22 @@ import supportsSchema from './features/schema';
 import supportsStrings from './features/strings';
 
 describe('RedshiftFormatter', () => {
-	const format = (query, cfg = {}) => sqlFormatter.format(query, { ...cfg, language: 'redshift' });
+	const language = 'redshift';
+	const format = (query, cfg = {}) => sqlFormatter.format(query, { ...cfg, language });
 
-	behavesLikeSqlFormatter(format);
-	supportsCreateTable(format);
-	supportsAlterTable(format);
-	supportsAlterTableModify(format);
-	supportsStrings(format, RedshiftFormatter.stringTypes);
-	supportsSchema(format);
+	behavesLikeSqlFormatter(language, format);
+	supportsCreateTable(language, format);
+	supportsAlterTable(language, format);
+	supportsAlterTableModify(language, format);
+	supportsStrings(language, format, RedshiftFormatter.stringTypes);
+	supportsSchema(language, format);
 	supportsOperators(
+		language,
 		format,
 		RedshiftFormatter.operators,
 		RedshiftFormatter.reservedLogicalOperators
 	);
-	supportsJoin(format);
+	supportsJoin(language, format);
 
 	it('formats LIMIT', () => {
 		expect(format('SELECT col1 FROM tbl ORDER BY col2 DESC LIMIT 10;')).toBe(dedent`

--- a/test/sparksql.test.js
+++ b/test/sparksql.test.js
@@ -13,21 +13,23 @@ import supportsSchema from './features/schema';
 import supportsStrings from './features/strings';
 
 describe('SparkSqlFormatter', () => {
-	const format = (query, cfg = {}) => sqlFormatter.format(query, { ...cfg, language: 'spark' });
+	const language = 'spark';
+	const format = (query, cfg = {}) => sqlFormatter.format(query, { ...cfg, language });
 
-	behavesLikeSqlFormatter(format);
-	supportsCase(format);
-	supportsCreateTable(format);
-	supportsAlterTable(format);
-	supportsStrings(format, SparkSqlFormatter.stringTypes);
-	supportsBetween(format);
-	supportsSchema(format);
+	behavesLikeSqlFormatter(language, format);
+	supportsCase(language, format);
+	supportsCreateTable(language, format);
+	supportsAlterTable(language, format);
+	supportsStrings(language, format, SparkSqlFormatter.stringTypes);
+	supportsBetween(language, format);
+	supportsSchema(language, format);
 	supportsOperators(
+		language,
 		format,
 		SparkSqlFormatter.operators,
 		SparkSqlFormatter.reservedLogicalOperators
 	);
-	supportsJoin(format, {
+	supportsJoin(language, format, {
 		additionally: [
 			'ANTI JOIN',
 			'SEMI JOIN',

--- a/test/sql.test.js
+++ b/test/sql.test.js
@@ -13,17 +13,19 @@ import supportsJoin from './features/join';
 import supportsOperators from './features/operators';
 
 describe('StandardSqlFormatter', () => {
-	const format = (query, cfg = {}) => sqlFormatter.format(query, { ...cfg, language: 'sql' });
+	const language = 'sql';
+	const format = (query, cfg = {}) => sqlFormatter.format(query, { ...cfg, language });
 
-	behavesLikeSqlFormatter(format);
-	supportsCase(format);
-	supportsCreateTable(format);
-	supportsAlterTable(format);
-	supportsStrings(format, StandardSqlFormatter.stringTypes);
-	supportsBetween(format);
-	supportsSchema(format);
-	supportsJoin(format);
+	behavesLikeSqlFormatter(language, format);
+	supportsCase(language, format);
+	supportsCreateTable(language, format);
+	supportsAlterTable(language, format);
+	supportsStrings(language, format, StandardSqlFormatter.stringTypes);
+	supportsBetween(language, format);
+	supportsSchema(language, format);
+	supportsJoin(language, format);
 	supportsOperators(
+		language,
 		format,
 		StandardSqlFormatter.operators,
 		StandardSqlFormatter.reservedLogicalOperators

--- a/test/tsql.test.js
+++ b/test/tsql.test.js
@@ -13,17 +13,23 @@ import supportsOperators from './features/operators';
 import supportsJoin from './features/join';
 
 describe('TSqlFormatter', () => {
-	const format = (query, cfg = {}) => sqlFormatter.format(query, { ...cfg, language: 'tsql' });
+	const language = 'tsql';
+	const format = (query, cfg = {}) => sqlFormatter.format(query, { ...cfg, language });
 
-	behavesLikeSqlFormatter(format);
-	supportsCase(format);
-	supportsCreateTable(format);
-	supportsAlterTable(format);
-	supportsStrings(format, TSqlFormatter.stringTypes);
-	supportsBetween(format);
-	supportsSchema(format);
-	supportsOperators(format, TSqlFormatter.operators, TSqlFormatter.reservedLogicalOperators);
-	supportsJoin(format, { without: ['NATURAL'] });
+	behavesLikeSqlFormatter(language, format);
+	supportsCase(language, format);
+	supportsCreateTable(language, format);
+	supportsAlterTable(language, format);
+	supportsStrings(language, format, TSqlFormatter.stringTypes);
+	supportsBetween(language, format);
+	supportsSchema(language, format);
+	supportsOperators(
+		language,
+		format,
+		TSqlFormatter.operators,
+		TSqlFormatter.reservedLogicalOperators
+	);
+	supportsJoin(language, format, { without: ['NATURAL'] });
 
 	// TODO: The following are duplicated from StandardSQLFormatter test
 

--- a/test/utils.js
+++ b/test/utils.js
@@ -1,0 +1,5 @@
+import { test } from '@jest/globals';
+
+export const itIf = condition => (condition ? test : test.skip);
+
+export default {};

--- a/vscode/.gitignore
+++ b/vscode/.gitignore
@@ -1,3 +1,5 @@
 node_modules/
 out/
 .vscode-test/
+
+*.vsix

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -67,17 +67,18 @@
 		"prettier-sql": "^5.1.0"
 	},
 	"devDependencies": {
-		"@types/vscode": "^1.63.0",
 		"@types/glob": "^7.1.4",
 		"@types/mocha": "^9.0.0",
 		"@types/node": "14.x",
+		"@types/vscode": "^1.63.0",
 		"@typescript-eslint/eslint-plugin": "^5.1.0",
 		"@typescript-eslint/parser": "^5.1.0",
+		"@vscode/test-electron": "^1.6.2",
+		"esbuild": "^0.14.8",
 		"eslint": "^8.1.0",
 		"glob": "^7.1.7",
 		"mocha": "^9.1.3",
-		"typescript": "^4.4.4",
-		"@vscode/test-electron": "^1.6.2"
+		"typescript": "^4.4.4"
 	},
 	"contributes": {
 		"languages": [

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -198,31 +198,36 @@
 					"default": "after",
 					"markdownDescription": "Where to place commas for SELECT and GROUP BY clauses"
 				},
-				"Prettier-SQL.keywordNewline": {
-					"type": [
-						"string",
-						"integer"
-					],
+				"Prettier-SQL.keywordNewline.newlineMode": {
+					"type": "string",
 					"enum": [
 						"always",
 						"lineWidth",
+						"itemCount",
 						"never"
 					],
 					"markdownEnumDescriptions": [
 						"Always break keywords items onto a newline",
 						"Break onto newline when line width > `#Prettier-SQL.lineWidth#` ",
+						"Break onto newline when item count > `#Prettier-SQL.itemCount#` ",
 						"Place all selected columns on the same line as keyword"
 					],
 					"minimum": 1,
 					"default": "always",
-					"markdownDescription": "Rule for when to break keyword clauses onto a newline, pass integer to break after n items"
+					"markdownDescription": "Rule for when to break keyword clauses onto a newline"
 				},
-				"Prettier-SQL.openParenNewline": {
+				"Prettier-SQL.keywordNewline.itemCount": {
+					"type": "number",
+					"minimum": 1,
+					"default": 3,
+					"markdownDescription": "Breaks keywords clauses onto newline after n items when `#Prettier-SQL.keywordNewline#` is set to itemCount"
+				},
+				"Prettier-SQL.parenOptions.openParenNewline": {
 					"type": "boolean",
 					"default": false,
 					"markdownDescription": "Place (, Open Paren, CASE on newline when creating a new block"
 				},
-				"Prettier-SQL.closeParenNewline": {
+				"Prettier-SQL.parenOptions.closeParenNewline": {
 					"type": "boolean",
 					"default": true,
 					"markdownDescription": "Place ), Close Paren, END on newline when closing a block"

--- a/vscode/src/extension.ts
+++ b/vscode/src/extension.ts
@@ -34,10 +34,13 @@ const getConfigs = (
 		aliasAs: settings.get<AliasMode>('aliasAS'),
 		tabulateAlias: settings.get<boolean>('tabulateAlias'),
 		commaPosition: settings.get<CommaPosition>('commaPosition'),
-		newlineOptions: settings.get<NewlineMode | number>('keywordNewline'),
+		newline: (newlineSetting =>
+			newlineSetting === 'itemCount'
+				? settings.get<number>('itemCount')
+				: (newlineSetting as NewlineMode))(settings.get<string>('keywordNewline')),
 		parenOptions: {
-			openParenNewline: settings.get<boolean>('openParenNewline'),
-			closeParenNewline: settings.get<boolean>('closeParenNewline'),
+			openParenNewline: settings.get<boolean>('parenOptions.openParenNewline'),
+			closeParenNewline: settings.get<boolean>('parenOptions.closeParenNewline'),
 		},
 		lineWidth: settings.get<number>('lineWidth'),
 		linesBetweenQueries: settings.get<number>('linesBetweenQueries'),
@@ -103,22 +106,14 @@ export function activate(context: vscode.ExtensionContext) {
 			const formatterLanguage = languages[documentLanguage] ?? 'sql';
 
 			const settings = vscode.workspace.getConfiguration('Prettier-SQL');
-			const ignoreTabSettings = settings.get<boolean>('ignoreTabSettings');
 
 			const workspaceConfig = vscode.workspace.getConfiguration('editor');
-			const options = {
-				...{
-					tabSize: settings.get<number>('tabSizeOverride')!,
-					insertSpaces: settings.get<boolean>('insertSpacesOverride')!,
-				},
-				...(ignoreTabSettings
-					? {}
-					: {
-							tabSize: workspaceConfig.get<number>('tabSize'),
-							insertSpaces: workspaceConfig.get<boolean>('insertSpaces'),
-					  }),
+			const tabOptions = {
+				tabSize: workspaceConfig.get<number>('tabSize')!,
+				insertSpaces: workspaceConfig.get<boolean>('insertSpaces')!,
 			};
-			const formatConfigs = getConfigs(settings, options, formatterLanguage);
+
+			const formatConfigs = getConfigs(settings, tabOptions, formatterLanguage);
 
 			const editor = vscode.window.activeTextEditor;
 			try {

--- a/vscode/yarn.lock
+++ b/vscode/yarn.lock
@@ -442,6 +442,120 @@ enquirer@^2.3.5:
   dependencies:
     ansi-colors "^4.1.1"
 
+esbuild-android-arm64@0.14.8:
+  version "0.14.8"
+  resolved "https://registry.yarnpkg.com/esbuild-android-arm64/-/esbuild-android-arm64-0.14.8.tgz#69324e08ba68c7d9a541e7b825d7235b83e17bd6"
+  integrity sha512-tAEoSHnPBSH0cCAFa/aYs3LPsoTY4SwsP6wDKi4PaelbQYNJjqNpAeweyJ8l98g1D6ZkLyqsHbkYj+209sezkA==
+
+esbuild-darwin-64@0.14.8:
+  version "0.14.8"
+  resolved "https://registry.yarnpkg.com/esbuild-darwin-64/-/esbuild-darwin-64-0.14.8.tgz#7176b692b9de746ba2f9dd4dd81dc4f1b7670786"
+  integrity sha512-t7p7WzTb+ybiD/irkMt5j/NzB+jY+8yPTsrXk5zCOH1O7DdthRnAUJ7pJPwImdL7jAGRbLtYRxUPgCHs/0qUPw==
+
+esbuild-darwin-arm64@0.14.8:
+  version "0.14.8"
+  resolved "https://registry.yarnpkg.com/esbuild-darwin-arm64/-/esbuild-darwin-arm64-0.14.8.tgz#59167584e58428877e48e05c4cca58755f843327"
+  integrity sha512-5FeaT2zMUajKnBwUMSsjZev5iA38YHrDmXhkOCwZQIFUvhqojinqCrvv/X7dyxb1987bcY9KGwJ+EwDwd922HQ==
+
+esbuild-freebsd-64@0.14.8:
+  version "0.14.8"
+  resolved "https://registry.yarnpkg.com/esbuild-freebsd-64/-/esbuild-freebsd-64-0.14.8.tgz#00b7d6e00abba9c2eccc9acd576c796333671e9c"
+  integrity sha512-pGHBLSf7ynfyDZXUtbq/GsA2VIwQlWXrUj1AMcE0id47mRdEUM8/1ZuqMGZx63hRnNgtK9zNJ8OIu2c7qq76Qw==
+
+esbuild-freebsd-arm64@0.14.8:
+  version "0.14.8"
+  resolved "https://registry.yarnpkg.com/esbuild-freebsd-arm64/-/esbuild-freebsd-arm64-0.14.8.tgz#57f0cd5a1cb37fa2c0e84e780677fe62f1e8c894"
+  integrity sha512-g4GgAnrx6Gh1BjKJjJWgPnOR4tW2FcAx9wFvyUjRsIjB35gT+aAFR+P/zStu5OG9LnbS8Pvjd4wS68QIXk+2dA==
+
+esbuild-linux-32@0.14.8:
+  version "0.14.8"
+  resolved "https://registry.yarnpkg.com/esbuild-linux-32/-/esbuild-linux-32-0.14.8.tgz#bbf3e5d3fb30f949030d0c2241ac93a172917d56"
+  integrity sha512-wPfQJadF5vTzriw/B8Ide74PeAJlZW7czNx3NIUHkHlXb+En1SeIqNzl6jG9DuJUl57xD9Ucl9YJFEkFeX8eLg==
+
+esbuild-linux-64@0.14.8:
+  version "0.14.8"
+  resolved "https://registry.yarnpkg.com/esbuild-linux-64/-/esbuild-linux-64-0.14.8.tgz#08631e9e0da613603bcec782f29fecbc6f4596de"
+  integrity sha512-+RNuLk9RhRDL2kG+KTEYl5cIgF6AGLkRnKKWEu9DpCZaickONEqrKyQSVn410Hj105DLdW6qvIXQQHPycJhExg==
+
+esbuild-linux-arm64@0.14.8:
+  version "0.14.8"
+  resolved "https://registry.yarnpkg.com/esbuild-linux-arm64/-/esbuild-linux-arm64-0.14.8.tgz#206d39c8dfbb7c72aa2f5fc52f7402b5b8a77366"
+  integrity sha512-BtWoKNYul9UoxUvQUSdSrvSmJyFL1sGnNPTSqWCg1wMe4kmc8UY2yVsXSSkKO8N2jtHxlgFyz/XhvNBzEwGVcw==
+
+esbuild-linux-arm@0.14.8:
+  version "0.14.8"
+  resolved "https://registry.yarnpkg.com/esbuild-linux-arm/-/esbuild-linux-arm-0.14.8.tgz#e28e70420d187f5e403bfa4a72df676d53d707fd"
+  integrity sha512-HIct38SvUAIJbiTwV/PVQroimQo96TGtzRDAEZxTorB4vsAj1r8bd0keXExPU4RH7G0zIqC4loQQpWYL+nH4Vg==
+
+esbuild-linux-mips64le@0.14.8:
+  version "0.14.8"
+  resolved "https://registry.yarnpkg.com/esbuild-linux-mips64le/-/esbuild-linux-mips64le-0.14.8.tgz#04997ac1a0df794a4d5e04d78015863d48490590"
+  integrity sha512-0DxnCl9XTvaQtsX6Qa+Phr5i9b04INwwSv2RbQ2UWRLoQ/037iaFzbmuhgrcmaGOcRwPkCa+4Qo5EgI01MUgsQ==
+
+esbuild-linux-ppc64le@0.14.8:
+  version "0.14.8"
+  resolved "https://registry.yarnpkg.com/esbuild-linux-ppc64le/-/esbuild-linux-ppc64le-0.14.8.tgz#1827378feff9702c156047ba118c1f3bd74da67e"
+  integrity sha512-Uzr/OMj97Q0qoWLXCvXCKUY/z1SNI4iSZEuYylM5Nd71HGStL32XWq/MReJ0PYMvUMKKJicKSKw2jWM1uBQ84Q==
+
+esbuild-linux-s390x@0.14.8:
+  version "0.14.8"
+  resolved "https://registry.yarnpkg.com/esbuild-linux-s390x/-/esbuild-linux-s390x-0.14.8.tgz#200ac44cda59b81135b325c3a29d016969650876"
+  integrity sha512-vURka7aCA5DrRoOqOn6pXYwFlDSoQ4qnqam8AC0Ikn6tibutuhgar6M3Ek2DCuz9yqd396mngdYr5A8x2TPkww==
+
+esbuild-netbsd-64@0.14.8:
+  version "0.14.8"
+  resolved "https://registry.yarnpkg.com/esbuild-netbsd-64/-/esbuild-netbsd-64-0.14.8.tgz#8159d8eae111f80ea6e4cbfa5d4cf658388a72d4"
+  integrity sha512-tjyDak2/pp0VUAhBW6/ueuReMd5qLHNlisXl5pq0Xn0z+kH9urA/t1igm0JassWbdMz123td5ZEQWoD9KbtOAw==
+
+esbuild-openbsd-64@0.14.8:
+  version "0.14.8"
+  resolved "https://registry.yarnpkg.com/esbuild-openbsd-64/-/esbuild-openbsd-64-0.14.8.tgz#2a9498d881a3ab94927c724f34dd1160eef1f3b8"
+  integrity sha512-zAKKV15fIyAuDDga5rQv0lW2ufBWj/OCjqjDBb3dJf5SfoAi/DMIHuzmkKQeDQ+oxt9Rp1D7ZOlOBVflutFTqQ==
+
+esbuild-sunos-64@0.14.8:
+  version "0.14.8"
+  resolved "https://registry.yarnpkg.com/esbuild-sunos-64/-/esbuild-sunos-64-0.14.8.tgz#2447de7d79848ad528c7d44caab4938eb8f5a0cc"
+  integrity sha512-xV41Wa8imziM/2dbWZjLKQbIETRgo5dE0oc/uPsgaecJhsrdA0VkGa/V432LJSUYv967xHDQdoRRl5tr80+NnQ==
+
+esbuild-windows-32@0.14.8:
+  version "0.14.8"
+  resolved "https://registry.yarnpkg.com/esbuild-windows-32/-/esbuild-windows-32-0.14.8.tgz#3287281552d7e4c851b3106940ff5826f518043e"
+  integrity sha512-AxpdeLKQSyCZo7MzdOyV4OgEbEJcjnrS/2niAjbHESbjuS5P1DN/5vZoJ/JSWDVa/40OkBuHBhAXMx1HK3UDsg==
+
+esbuild-windows-64@0.14.8:
+  version "0.14.8"
+  resolved "https://registry.yarnpkg.com/esbuild-windows-64/-/esbuild-windows-64-0.14.8.tgz#b4052868438b4f17b5c2a908cf344ed2bd267c38"
+  integrity sha512-/3pllNoy8mrz/E1rYalwiwwhzJBrYQhEapwAteHZbFVhGzYuB8F80e8x5eA8dhFHxDiZh1VzK+hREwwSt8UTQA==
+
+esbuild-windows-arm64@0.14.8:
+  version "0.14.8"
+  resolved "https://registry.yarnpkg.com/esbuild-windows-arm64/-/esbuild-windows-arm64-0.14.8.tgz#512d06097cb4b848526a37c48a47223f1c6cc667"
+  integrity sha512-lTm5naoNgaUvzIiax3XYIEebqwr3bIIEEtqUhzQ2UQ+JMBmvhr02w3sJIJqF3axTX6TgWrC1OtM7DYNvFG+aXA==
+
+esbuild@^0.14.8:
+  version "0.14.8"
+  resolved "https://registry.yarnpkg.com/esbuild/-/esbuild-0.14.8.tgz#f60a07ca9400d61d09a98f96d666c50613972550"
+  integrity sha512-stMsCBmxwaMpeK8GC/49L/cRGIwsHwoEN7Twk5zDTHlm/63c0KXFKzDC8iM2Mi3fyCKwS002TAH6IlAvqR6t3g==
+  optionalDependencies:
+    esbuild-android-arm64 "0.14.8"
+    esbuild-darwin-64 "0.14.8"
+    esbuild-darwin-arm64 "0.14.8"
+    esbuild-freebsd-64 "0.14.8"
+    esbuild-freebsd-arm64 "0.14.8"
+    esbuild-linux-32 "0.14.8"
+    esbuild-linux-64 "0.14.8"
+    esbuild-linux-arm "0.14.8"
+    esbuild-linux-arm64 "0.14.8"
+    esbuild-linux-mips64le "0.14.8"
+    esbuild-linux-ppc64le "0.14.8"
+    esbuild-linux-s390x "0.14.8"
+    esbuild-netbsd-64 "0.14.8"
+    esbuild-openbsd-64 "0.14.8"
+    esbuild-sunos-64 "0.14.8"
+    esbuild-windows-32 "0.14.8"
+    esbuild-windows-64 "0.14.8"
+    esbuild-windows-arm64 "0.14.8"
+
 escalade@^3.1.1:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/escalade/-/escalade-3.1.1.tgz#d8cfdc7000965c5a0174b4a82eaa5c0552742e40"
@@ -1063,10 +1177,10 @@ prelude-ls@^1.2.1:
   resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.2.1.tgz#debc6489d7a6e6b0e7611888cec880337d316396"
   integrity sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==
 
-prettier-sql@^5.0.1:
-  version "5.0.1"
-  resolved "https://registry.yarnpkg.com/prettier-sql/-/prettier-sql-5.0.1.tgz#6434953e7e20c279a6fe2abce64a7f7488fcc7c9"
-  integrity sha512-bjcOltr044ktVM4UUr7Vi0V4wJlk1Uke9ONS8VU6ekee/2GsDw8EpYmOjZjPqGzO0tsthj8QizzmiLmn3GnJFA==
+prettier-sql@^5.1.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/prettier-sql/-/prettier-sql-5.1.0.tgz#cb5dcea3904ff628abf7ebf1ca61a4c1eb7779d3"
+  integrity sha512-85IvpNNDhECsIjb7rImLo5JIIcwssgx63NPbnlEUtsjHMN28Aik8xmFYLXesq09oGS3KX7COfINmKttVPvRrCw==
   dependencies:
     argparse "^2.0.1"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -32,6 +32,13 @@
   dependencies:
     "@babel/highlight" "^7.14.5"
 
+"@babel/code-frame@^7.12.13":
+  version "7.16.7"
+  resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.16.7.tgz#44416b6bd7624b998f5b1af5d470856c40138789"
+  integrity sha512-iAXqUn8IIeBTNd72xsFlgaXHkMBMt6y4HJp1tIaK465CWLT/fG1aqB7ykr95gHHmlBdGbFeWWfyB4NJJ0nmeIg==
+  dependencies:
+    "@babel/highlight" "^7.16.7"
+
 "@babel/compat-data@^7.13.11", "@babel/compat-data@^7.14.7", "@babel/compat-data@^7.15.0":
   version "7.15.0"
   resolved "https://registry.yarnpkg.com/@babel/compat-data/-/compat-data-7.15.0.tgz#2dbaf8b85334796cafbb0f5793a90a2fc010b176"
@@ -241,6 +248,11 @@
   resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.14.9.tgz#6654d171b2024f6d8ee151bf2509699919131d48"
   integrity sha512-pQYxPY0UP6IHISRitNe8bsijHex4TWZXi2HwKVsjPiltzlhse2znVcm9Ace510VT1kxIHjGJCZZQBX2gJDbo0g==
 
+"@babel/helper-validator-identifier@^7.16.7":
+  version "7.16.7"
+  resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.16.7.tgz#e8c602438c4a8195751243da9031d1607d247cad"
+  integrity sha512-hsEnFemeiW4D08A5gUAZxLBTXpZ39P+a+DGDsHw1yxqyQ/jzFEnxf5uTEGp+3bzAbNOxU1paTgYS4ECU/IgfDw==
+
 "@babel/helper-validator-option@^7.14.5":
   version "7.14.5"
   resolved "https://registry.yarnpkg.com/@babel/helper-validator-option/-/helper-validator-option-7.14.5.tgz#6e72a1fff18d5dfcb878e1e62f1a021c4b72d5a3"
@@ -271,6 +283,15 @@
   integrity sha512-qf9u2WFWVV0MppaL877j2dBtQIDgmidgjGk5VIMw3OadXvYaXn66U1BFlH2t4+t3i+8PhedppRv+i40ABzd+gg==
   dependencies:
     "@babel/helper-validator-identifier" "^7.14.5"
+    chalk "^2.0.0"
+    js-tokens "^4.0.0"
+
+"@babel/highlight@^7.16.7":
+  version "7.16.10"
+  resolved "https://registry.yarnpkg.com/@babel/highlight/-/highlight-7.16.10.tgz#744f2eb81579d6eea753c227b0f570ad785aba88"
+  integrity sha512-5FnTQLSLswEj6IkgVw5KusNUUFY9ZGqe/TRFnP/BKYHYgfh7tc+C7mwiy95/yNP7Dh9x580Vv8r7u7ZfTBFxdw==
+  dependencies:
+    "@babel/helper-validator-identifier" "^7.16.7"
     chalk "^2.0.0"
     js-tokens "^4.0.0"
 
@@ -1054,6 +1075,16 @@
     "@types/node" "*"
     jest-mock "^26.6.2"
 
+"@jest/environment@^27.5.1":
+  version "27.5.1"
+  resolved "https://registry.yarnpkg.com/@jest/environment/-/environment-27.5.1.tgz#d7425820511fe7158abbecc010140c3fd3be9c74"
+  integrity sha512-/WQjhPJe3/ghaol/4Bq480JKXV/Rfw8nQdN7f41fM8VDHLcxKXou6QyXAh3EFr9/bVG3x74z1NWDkP87EiY8gA==
+  dependencies:
+    "@jest/fake-timers" "^27.5.1"
+    "@jest/types" "^27.5.1"
+    "@types/node" "*"
+    jest-mock "^27.5.1"
+
 "@jest/fake-timers@^26.6.2":
   version "26.6.2"
   resolved "https://registry.yarnpkg.com/@jest/fake-timers/-/fake-timers-26.6.2.tgz#459c329bcf70cee4af4d7e3f3e67848123535aad"
@@ -1066,6 +1097,18 @@
     jest-mock "^26.6.2"
     jest-util "^26.6.2"
 
+"@jest/fake-timers@^27.5.1":
+  version "27.5.1"
+  resolved "https://registry.yarnpkg.com/@jest/fake-timers/-/fake-timers-27.5.1.tgz#76979745ce0579c8a94a4678af7a748eda8ada74"
+  integrity sha512-/aPowoolwa07k7/oM3aASneNeBGCmGQsc3ugN4u6s4C/+s5M64MFo/+djTdiwcbQlRfFElGuDXWzaWj6QgKObQ==
+  dependencies:
+    "@jest/types" "^27.5.1"
+    "@sinonjs/fake-timers" "^8.0.1"
+    "@types/node" "*"
+    jest-message-util "^27.5.1"
+    jest-mock "^27.5.1"
+    jest-util "^27.5.1"
+
 "@jest/globals@^26.6.2":
   version "26.6.2"
   resolved "https://registry.yarnpkg.com/@jest/globals/-/globals-26.6.2.tgz#5b613b78a1aa2655ae908eba638cc96a20df720a"
@@ -1074,6 +1117,15 @@
     "@jest/environment" "^26.6.2"
     "@jest/types" "^26.6.2"
     expect "^26.6.2"
+
+"@jest/globals@^27.5.1":
+  version "27.5.1"
+  resolved "https://registry.yarnpkg.com/@jest/globals/-/globals-27.5.1.tgz#7ac06ce57ab966566c7963431cef458434601b2b"
+  integrity sha512-ZEJNB41OBQQgGzgyInAv0UUfDDj3upmHydjieSxFvTRuZElrx7tXg/uVQ5hYVEwiXs3+aMsAeEc9X7xiSKCm4Q==
+  dependencies:
+    "@jest/environment" "^27.5.1"
+    "@jest/types" "^27.5.1"
+    expect "^27.5.1"
 
 "@jest/reporters@^26.6.2":
   version "26.6.2"
@@ -1167,6 +1219,17 @@
     "@types/istanbul-reports" "^3.0.0"
     "@types/node" "*"
     "@types/yargs" "^15.0.0"
+    chalk "^4.0.0"
+
+"@jest/types@^27.5.1":
+  version "27.5.1"
+  resolved "https://registry.yarnpkg.com/@jest/types/-/types-27.5.1.tgz#3c79ec4a8ba61c170bf937bcf9e98a9df175ec80"
+  integrity sha512-Cx46iJ9QpwQTjIdq5VJu2QTMMs3QlEjI0x1QbBP5W1+nMzyc2XmimiRR/CbX9TO0cPTeUlxWMOu8mslYsJ8DEw==
+  dependencies:
+    "@types/istanbul-lib-coverage" "^2.0.0"
+    "@types/istanbul-reports" "^3.0.0"
+    "@types/node" "*"
+    "@types/yargs" "^16.0.0"
     chalk "^4.0.0"
 
 "@nicolo-ribaudo/chokidar-2@2.1.8-no-fsevents.2":
@@ -1329,6 +1392,13 @@
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/@sinonjs/fake-timers/-/fake-timers-6.0.1.tgz#293674fccb3262ac782c7aadfdeca86b10c75c40"
   integrity sha512-MZPUxrmFubI36XS1DI3qmI0YdN1gks62JtFZvxR67ljjSNCeK6U08Zx4msEWOXuofgqUt6zPHSi1H9fbjR/NRA==
+  dependencies:
+    "@sinonjs/commons" "^1.7.0"
+
+"@sinonjs/fake-timers@^8.0.1":
+  version "8.1.0"
+  resolved "https://registry.yarnpkg.com/@sinonjs/fake-timers/-/fake-timers-8.1.0.tgz#3fdc2b6cb58935b21bfb8d1625eb1300484316e7"
+  integrity sha512-OAPJUAtgeINhh/TAlUID4QTs53Njm7xzddaVlEs/SXwgtiD1tW22zAB/W1wdqfrpmikgaWQ9Fw6Ws+hsiRm5Vg==
   dependencies:
     "@sinonjs/commons" "^1.7.0"
 
@@ -1499,6 +1569,13 @@
   version "15.0.14"
   resolved "https://registry.yarnpkg.com/@types/yargs/-/yargs-15.0.14.tgz#26d821ddb89e70492160b66d10a0eb6df8f6fb06"
   integrity sha512-yEJzHoxf6SyQGhBhIYGXQDSCkJjB6HohDShto7m8vaKg9Yp0Yn8+71J9eakh2bnPg6BfsH9PRMhiRTZnd4eXGQ==
+  dependencies:
+    "@types/yargs-parser" "*"
+
+"@types/yargs@^16.0.0":
+  version "16.0.4"
+  resolved "https://registry.yarnpkg.com/@types/yargs/-/yargs-16.0.4.tgz#26aad98dd2c2a38e421086ea9ad42b9e51642977"
+  integrity sha512-T8Yc9wt/5LbJyCaLiHPReJa0kApcIgJ7Bn735GjItUfh08Z1pJvu8QZqb9s+mMvKV6WUQRV7K2R46YbjMXTTJw==
   dependencies:
     "@types/yargs-parser" "*"
 
@@ -1870,6 +1947,11 @@ ansi-styles@^4.0.0, ansi-styles@^4.1.0:
   integrity sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==
   dependencies:
     color-convert "^2.0.1"
+
+ansi-styles@^5.0.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-5.2.0.tgz#07449690ad45777d1924ac2abb2fc8895dba836b"
+  integrity sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==
 
 anymatch@^2.0.0:
   version "2.0.0"
@@ -2387,6 +2469,11 @@ ci-info@^3.1.1:
   resolved "https://registry.yarnpkg.com/ci-info/-/ci-info-3.2.0.tgz#2876cb948a498797b5236f0095bc057d0dca38b6"
   integrity sha512-dVqRX7fLUm8J6FgHJ418XuIgDLZDkYcDFTeL6TA2gt5WlIZUQrrH6EZrNClwT/H0FateUsZkGIOPRrLbP+PR9A==
 
+ci-info@^3.2.0:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/ci-info/-/ci-info-3.3.0.tgz#b4ed1fb6818dea4803a55c623041f9165d2066b2"
+  integrity sha512-riT/3vI5YpVH6/qomlDnJow6TBee2PBKSEpx3O32EGPYbWGIRsIlGRms3Sm74wYE1JMo8RnO04Hb12+v1J5ICw==
+
 cjs-module-lexer@^0.6.0:
   version "0.6.0"
   resolved "https://registry.yarnpkg.com/cjs-module-lexer/-/cjs-module-lexer-0.6.0.tgz#4186fcca0eae175970aee870b9fe2d6cf8d5655f"
@@ -2809,6 +2896,11 @@ diff-sequences@^26.6.2:
   version "26.6.2"
   resolved "https://registry.yarnpkg.com/diff-sequences/-/diff-sequences-26.6.2.tgz#48ba99157de1923412eed41db6b6d4aa9ca7c0b1"
   integrity sha512-Mv/TDa3nZ9sbc5soK+OoA74BsS3mL37yixCvUAQkiuA4Wz6YtwP/K47n2rv2ovzHZvoiQeA5FTQOschKkEwB0Q==
+
+diff-sequences@^27.5.1:
+  version "27.5.1"
+  resolved "https://registry.yarnpkg.com/diff-sequences/-/diff-sequences-27.5.1.tgz#eaecc0d327fd68c8d9672a1e64ab8dccb2ef5327"
+  integrity sha512-k1gCAXAsNgLwEL+Y8Wvl+M6oEFj5bgazfZULpS5CneoPPXRaCCW7dm+q21Ky2VEE5X+VeRDBVg1Pcvvsr4TtNQ==
 
 dir-glob@^3.0.1:
   version "3.0.1"
@@ -3252,6 +3344,16 @@ expect@^26.6.2:
     jest-message-util "^26.6.2"
     jest-regex-util "^26.0.0"
 
+expect@^27.5.1:
+  version "27.5.1"
+  resolved "https://registry.yarnpkg.com/expect/-/expect-27.5.1.tgz#83ce59f1e5bdf5f9d2b94b61d2050db48f3fef74"
+  integrity sha512-E1q5hSUG2AmYQwQJ041nvgpkODHQvB+RKlB4IYdru6uJsyFTRyZAP463M+1lINorwbqAmUggi6+WwkD8lCS/Dw==
+  dependencies:
+    "@jest/types" "^27.5.1"
+    jest-get-type "^27.5.1"
+    jest-matcher-utils "^27.5.1"
+    jest-message-util "^27.5.1"
+
 extend-shallow@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/extend-shallow/-/extend-shallow-2.0.1.tgz#51af7d614ad9a9f610ea1bafbb989d6b1c56890f"
@@ -3634,6 +3736,11 @@ graceful-fs@^4.1.11, graceful-fs@^4.1.2, graceful-fs@^4.2.4:
   version "4.2.8"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.8.tgz#e412b8d33f5e006593cbd3cee6df9f2cebbe802a"
   integrity sha512-qkIilPUYcNhJpd33n0GBXTB1MMPp14TxEsEs0pTrsSVucApsYzW5V+Q8Qxhik6KU3evy+qkAAowTByymK0avdg==
+
+graceful-fs@^4.2.9:
+  version "4.2.10"
+  resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.10.tgz#147d3a006da4ca3ce14728c7aefc287c367d7a6c"
+  integrity sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==
 
 growly@^1.3.0:
   version "1.3.0"
@@ -4306,6 +4413,16 @@ jest-diff@^26.6.2:
     jest-get-type "^26.3.0"
     pretty-format "^26.6.2"
 
+jest-diff@^27.5.1:
+  version "27.5.1"
+  resolved "https://registry.yarnpkg.com/jest-diff/-/jest-diff-27.5.1.tgz#a07f5011ac9e6643cf8a95a462b7b1ecf6680def"
+  integrity sha512-m0NvkX55LDt9T4mctTEgnZk3fmEg3NRYutvMPWM/0iPnkFj2wIeF45O1718cMSOFO1vINkqmxqD8vE37uTEbqw==
+  dependencies:
+    chalk "^4.0.0"
+    diff-sequences "^27.5.1"
+    jest-get-type "^27.5.1"
+    pretty-format "^27.5.1"
+
 jest-docblock@^26.0.0:
   version "26.0.0"
   resolved "https://registry.yarnpkg.com/jest-docblock/-/jest-docblock-26.0.0.tgz#3e2fa20899fc928cb13bd0ff68bd3711a36889b5"
@@ -4353,6 +4470,11 @@ jest-get-type@^26.3.0:
   version "26.3.0"
   resolved "https://registry.yarnpkg.com/jest-get-type/-/jest-get-type-26.3.0.tgz#e97dc3c3f53c2b406ca7afaed4493b1d099199e0"
   integrity sha512-TpfaviN1R2pQWkIihlfEanwOXK0zcxrKEE4MlU6Tn7keoXdN6/3gK/xl0yEh8DOunn5pOVGKf8hB4R9gVh04ig==
+
+jest-get-type@^27.5.1:
+  version "27.5.1"
+  resolved "https://registry.yarnpkg.com/jest-get-type/-/jest-get-type-27.5.1.tgz#3cd613c507b0f7ace013df407a1c1cd578bcb4f1"
+  integrity sha512-2KY95ksYSaK7DMBWQn6dQz3kqAf3BB64y2udeG+hv4KfSOb9qwcYQstTJc1KCbsix+wLZWZYN8t7nwX3GOBLRw==
 
 jest-haste-map@^26.6.2:
   version "26.6.2"
@@ -4417,6 +4539,16 @@ jest-matcher-utils@^26.6.2:
     jest-get-type "^26.3.0"
     pretty-format "^26.6.2"
 
+jest-matcher-utils@^27.5.1:
+  version "27.5.1"
+  resolved "https://registry.yarnpkg.com/jest-matcher-utils/-/jest-matcher-utils-27.5.1.tgz#9c0cdbda8245bc22d2331729d1091308b40cf8ab"
+  integrity sha512-z2uTx/T6LBaCoNWNFWwChLBKYxTMcGBRjAt+2SbP929/Fflb9aa5LGma654Rz8z9HLxsrUaYzxE9T/EFIL/PAw==
+  dependencies:
+    chalk "^4.0.0"
+    jest-diff "^27.5.1"
+    jest-get-type "^27.5.1"
+    pretty-format "^27.5.1"
+
 jest-message-util@^26.6.2:
   version "26.6.2"
   resolved "https://registry.yarnpkg.com/jest-message-util/-/jest-message-util-26.6.2.tgz#58173744ad6fc0506b5d21150b9be56ef001ca07"
@@ -4432,12 +4564,35 @@ jest-message-util@^26.6.2:
     slash "^3.0.0"
     stack-utils "^2.0.2"
 
+jest-message-util@^27.5.1:
+  version "27.5.1"
+  resolved "https://registry.yarnpkg.com/jest-message-util/-/jest-message-util-27.5.1.tgz#bdda72806da10d9ed6425e12afff38cd1458b6cf"
+  integrity sha512-rMyFe1+jnyAAf+NHwTclDz0eAaLkVDdKVHHBFWsBWHnnh5YeJMNWWsv7AbFYXfK3oTqvL7VTWkhNLu1jX24D+g==
+  dependencies:
+    "@babel/code-frame" "^7.12.13"
+    "@jest/types" "^27.5.1"
+    "@types/stack-utils" "^2.0.0"
+    chalk "^4.0.0"
+    graceful-fs "^4.2.9"
+    micromatch "^4.0.4"
+    pretty-format "^27.5.1"
+    slash "^3.0.0"
+    stack-utils "^2.0.3"
+
 jest-mock@^26.6.2:
   version "26.6.2"
   resolved "https://registry.yarnpkg.com/jest-mock/-/jest-mock-26.6.2.tgz#d6cb712b041ed47fe0d9b6fc3474bc6543feb302"
   integrity sha512-YyFjePHHp1LzpzYcmgqkJ0nm0gg/lJx2aZFzFy1S6eUqNjXsOqTK10zNRff2dNfssgokjkG65OlWNcIlgd3zew==
   dependencies:
     "@jest/types" "^26.6.2"
+    "@types/node" "*"
+
+jest-mock@^27.5.1:
+  version "27.5.1"
+  resolved "https://registry.yarnpkg.com/jest-mock/-/jest-mock-27.5.1.tgz#19948336d49ef4d9c52021d34ac7b5f36ff967d6"
+  integrity sha512-K4jKbY1d4ENhbrG2zuPWaQBvDly+iZ2yAW+T1fATN78hc0sInwn7wZB8XtlNnvHug5RMwV897Xm4LqmPM4e2Og==
+  dependencies:
+    "@jest/types" "^27.5.1"
     "@types/node" "*"
 
 jest-pnp-resolver@^1.2.2:
@@ -4573,6 +4728,18 @@ jest-util@^26.6.2:
     graceful-fs "^4.2.4"
     is-ci "^2.0.0"
     micromatch "^4.0.2"
+
+jest-util@^27.5.1:
+  version "27.5.1"
+  resolved "https://registry.yarnpkg.com/jest-util/-/jest-util-27.5.1.tgz#3ba9771e8e31a0b85da48fe0b0891fb86c01c2f9"
+  integrity sha512-Kv2o/8jNvX1MQ0KGtw480E/w4fBCDOnH6+6DmeKi6LZUIlKA5kwY0YNdlzaWTiVgxqAqik11QyxDOKk543aKXw==
+  dependencies:
+    "@jest/types" "^27.5.1"
+    "@types/node" "*"
+    chalk "^4.0.0"
+    ci-info "^3.2.0"
+    graceful-fs "^4.2.9"
+    picomatch "^2.2.3"
 
 jest-validate@^26.6.2:
   version "26.6.2"
@@ -5592,6 +5759,15 @@ pretty-format@^26.6.2:
     ansi-styles "^4.0.0"
     react-is "^17.0.1"
 
+pretty-format@^27.5.1:
+  version "27.5.1"
+  resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-27.5.1.tgz#2181879fdea51a7a5851fb39d920faa63f01d88e"
+  integrity sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==
+  dependencies:
+    ansi-regex "^5.0.1"
+    ansi-styles "^5.0.0"
+    react-is "^17.0.1"
+
 process-nextick-args@~2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/process-nextick-args/-/process-nextick-args-2.0.1.tgz#7820d9b16120cc55ca9ae7792680ae7dba6d7fe2"
@@ -6358,6 +6534,13 @@ stack-utils@^2.0.2:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/stack-utils/-/stack-utils-2.0.3.tgz#cd5f030126ff116b78ccb3c027fe302713b61277"
   integrity sha512-gL//fkxfWUsIlFL2Tl42Cl6+HFALEaB1FU76I/Fy+oZjRreP7OPMXFlGbxM7NQsI0ZpUfw76sHnv0WNYuTb7Iw==
+  dependencies:
+    escape-string-regexp "^2.0.0"
+
+stack-utils@^2.0.3:
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/stack-utils/-/stack-utils-2.0.5.tgz#d25265fca995154659dbbfba3b49254778d2fdd5"
+  integrity sha512-xrQcmYhOsn/1kX+Vraq+7j4oE2j/6BFscZ0etmYg81xuM8Gq0022Pxb8+IqgOFUIaxHs0KaSb7T1+OegiNrNFA==
   dependencies:
     escape-string-regexp "^2.0.0"
 


### PR DESCRIPTION
- restored itemCount setting for VScode extension
- added JSDocs for all files
- added conditional skips for Jest tests
 - added missing BigQuery, hive from demo page language dropdown

- fixed bug with CASE and Inline Block interaction
- fixed bug with END not adding spacings before END
- fixed bug with CommaPosition.before when the line had no preceding whitespace
- fixed bug where AS in CAST functions would get deleted when AliasAs.never
- fixed bug where AS would get deleted in CTE definition when AliasAs.never